### PR TITLE
Add listener priority and image_repo_name

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
+
+
+
 ## Usage
 
 ```
@@ -63,6 +67,7 @@ Available targets:
 | alb_arn_suffix | ARN suffix of the ALB for the Target Group. | string | `` | no |
 | alb_ingress_healthcheck_path | The path of the healthcheck which the ALB checks. | string | `/` | no |
 | alb_ingress_hosts | Hosts to match in Hosts header, at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_listener_priority | Priority of the listeners, a number between 1 - 50000 (1 is highest priority) | string | `1000` | no |
 | alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
 | alb_name | Name of the ALB for the Target Group. | string | `` | no |
 | alb_target_group_alarms_3xx_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service. | string | `25` | no |
@@ -199,6 +204,13 @@ See [LICENSE](LICENSE) for full details.
     KIND, either express or implied.  See the License for the
     specific language governing permissions and limitations
     under the License.
+
+
+
+
+
+
+
 
 
 ## Trademarks

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -6,6 +6,7 @@
 | alb_arn_suffix | ARN suffix of the ALB for the Target Group. | string | `` | no |
 | alb_ingress_healthcheck_path | The path of the healthcheck which the ALB checks. | string | `/` | no |
 | alb_ingress_hosts | Hosts to match in Hosts header, at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_listener_priority | Priority of the listeners, a number between 1 - 50000 (1 is highest priority) | string | `1000` | no |
 | alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
 | alb_name | Name of the ALB for the Target Group. | string | `` | no |
 | alb_target_group_alarms_3xx_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service. | string | `25` | no |

--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ module "alb_ingress" {
   listener_arns_count = "${var.listener_arns_count}"
   health_check_path   = "${var.alb_ingress_healthcheck_path}"
   paths               = ["${var.alb_ingress_paths}"]
+  priority            = "${var.alb_ingress_listener_priority}"
   hosts               = ["${var.alb_ingress_hosts}"]
 }
 
@@ -72,6 +73,7 @@ module "ecs_codepipeline" {
   repo_owner         = "${var.repo_owner}"
   repo_name          = "${var.repo_name}"
   branch             = "${var.branch}"
+  image_repo_name    = "${module.ecr.repository_name}"
   service_name       = "${module.ecs_alb_service_task.service_name}"
   ecs_cluster_name   = "${var.ecs_cluster_name}"
   privileged_mode    = "true"

--- a/variables.tf
+++ b/variables.tf
@@ -144,16 +144,22 @@ variable "alb_ingress_healthcheck_path" {
   default     = "/"
 }
 
+variable "alb_ingress_hosts" {
+  type        = "list"
+  default     = []
+  description = "Hosts to match in Hosts header, at least one of hosts or paths must be set"
+}
+
 variable "alb_ingress_paths" {
   type        = "list"
   default     = []
   description = "Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set"
 }
 
-variable "alb_ingress_hosts" {
-  type        = "list"
-  default     = []
-  description = "Hosts to match in Hosts header, at least one of hosts or paths must be set"
+variable "alb_ingress_listener_priority" {
+  type        = "string"
+  default     = "1000"
+  description = "Priority of the listeners, a number between 1 - 50000 (1 is highest priority)"
 }
 
 variable "vpc_id" {


### PR DESCRIPTION
## what
Add `priority` parameter and set the `image_repo_name`.

## why
`priority` allows for having a default or fall back web app in order to serve nice error pages. This will allow to set the weight of each target. Priority can be a number between `1-50000`, where `1` is the highest priority. Defaults to `1000`.

`image_repo_name` should be set to the ECR repo name in order to get the codebuild upload to ECR steps working and uploading the images to the proper registry.