### PR TITLE
Add ECS Task IAM role ARN

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ It's 100% Open Source and licensed under the [APACHE2](LICENSE).
 
 
 
+
 ## Usage
 
 ```

--- a/README.md
+++ b/README.md
@@ -110,6 +110,12 @@ Available targets:
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
 | vpc_id | The VPC ID where resources are created. | string | - | yes |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| task_role_arn | ECS Task role ARN |
+
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -49,3 +49,9 @@
 | tags | Map of key-value pairs to use for tags. | map | `<map>` | no |
 | vpc_id | The VPC ID where resources are created. | string | - | yes |
 
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| task_role_arn | ECS Task role ARN |
+

--- a/main.tf
+++ b/main.tf
@@ -19,11 +19,11 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "alb_ingress" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.2.3"
+  source              = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.3.0"
   name                = "${var.name}"
   namespace           = "${var.namespace}"
   stage               = "${var.stage}"
-  attributes          = "${compact(concat(var.attributes, list("alb", "ingress")))}"
+  attributes          = "${var.attributes}"
   vpc_id              = "${var.vpc_id}"
   listener_arns       = ["${var.listener_arns}"]
   listener_arns_count = "${var.listener_arns_count}"
@@ -34,11 +34,12 @@ module "alb_ingress" {
 }
 
 module "container_definition" {
-  source           = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.1.3"
+  source           = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.1.4"
   container_name   = "${module.default_label.id}"
   container_image  = "${var.container_image}"
   container_memory = "${var.container_memory}"
   container_port   = "${var.container_port}"
+  healthcheck      = "${var.healthcheck}"
 
   log_options = {
     "awslogs-region"        = "${var.aws_logs_region}"
@@ -48,7 +49,7 @@ module "container_definition" {
 }
 
 module "ecs_alb_service_task" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=tags/0.2.1"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=tags/0.3.0"
   name                      = "${var.name}"
   namespace                 = "${var.namespace}"
   stage                     = "${var.stage}"
@@ -65,7 +66,7 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled            = "${var.codepipeline_enabled}"
-  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.1.2"
+  source             = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.2.0"
   name               = "${var.name}"
   namespace          = "${var.namespace}"
   stage              = "${var.stage}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,4 @@
+output "task_role_arn" {
+  description = "ECS Task role ARN"
+  value       = "${module.ecs_alb_service_task.task_role_arn}"
+}


### PR DESCRIPTION
## what
Add the output for ECS Task IAM role ARN

## why
Needed for attaching to external service policies outside of module.