### PR TITLE
Add autoscaling module

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,14 @@ Available targets:
 | alb_target_group_alarms_period | The period (in seconds) to analyze for ALB CloudWatch Alarms. | string | `300` | no |
 | alb_target_group_alarms_response_time_threshold | The maximum ALB Target Group response time. | string | `0.5` | no |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
+| autoscaling_dimension | Dimension to autoscale on (valid options: cpu, memory) | string | `memory` | no |
+| autoscaling_enabled | A boolean to enable/disable Autoscaling policy for ECS Service. | string | `false` | no |
+| autoscaling_max_capacity | Maximum number of running instances of a Service. | string | `2` | no |
+| autoscaling_min_capacity | Minimum number of running instances of a Service. | string | `1` | no |
+| autoscaling_scale_down_adjustment | Scaling adjustment to make during scale down event. | string | `-1` | no |
+| autoscaling_scale_down_cooldown | Period (in seconds) to wait between scale down events. | string | `300` | no |
+| autoscaling_scale_up_adjustment | Scaling adjustment to make during scale up event. | string | `1` | no |
+| autoscaling_scale_up_cooldown | Period (in seconds) to wait between scale up events. | string | `60` | no |
 | aws_logs_region | The region for the AWS Cloudwatch Logs group. | string | - | yes |
 | branch | Branch of the GitHub repository, e.g. master | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |
@@ -131,6 +139,9 @@ Available targets:
 
 | Name | Description |
 |------|-------------|
+| scale_down_policy_arn | Autoscaling scale up policy ARN |
+| scale_up_policy_arn | Autoscaling scale up policy ARN |
+| service_name | ECS Service Name |
 | task_role_arn | ECS Task role ARN |
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -17,6 +17,14 @@
 | alb_target_group_alarms_period | The period (in seconds) to analyze for ALB CloudWatch Alarms. | string | `300` | no |
 | alb_target_group_alarms_response_time_threshold | The maximum ALB Target Group response time. | string | `0.5` | no |
 | attributes | List of attributes to add to label. | list | `<list>` | no |
+| autoscaling_dimension | Dimension to autoscale on (valid options: cpu, memory) | string | `memory` | no |
+| autoscaling_enabled | A boolean to enable/disable Autoscaling policy for ECS Service. | string | `false` | no |
+| autoscaling_max_capacity | Maximum number of running instances of a Service. | string | `2` | no |
+| autoscaling_min_capacity | Minimum number of running instances of a Service. | string | `1` | no |
+| autoscaling_scale_down_adjustment | Scaling adjustment to make during scale down event. | string | `-1` | no |
+| autoscaling_scale_down_cooldown | Period (in seconds) to wait between scale down events. | string | `300` | no |
+| autoscaling_scale_up_adjustment | Scaling adjustment to make during scale up event. | string | `1` | no |
+| autoscaling_scale_up_cooldown | Period (in seconds) to wait between scale up events. | string | `60` | no |
 | aws_logs_region | The region for the AWS Cloudwatch Logs group. | string | - | yes |
 | branch | Branch of the GitHub repository, e.g. master | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |
@@ -69,5 +77,8 @@
 
 | Name | Description |
 |------|-------------|
+| scale_down_policy_arn | Autoscaling scale up policy ARN |
+| scale_up_policy_arn | Autoscaling scale up policy ARN |
+| service_name | ECS Service Name |
 | task_role_arn | ECS Task role ARN |
 

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,23 @@ module "ecs_codepipeline" {
   }]
 }
 
+module "autoscaling" {
+  enabled      = "${var.autoscaling_enabled}"
+  source       = "../terraform-aws-ecs-cloudwatch-autoscaling"
+  name         = "${var.name}"
+  namespace    = "${var.namespace}"
+  stage        = "${var.stage}"
+  service_name = "${module.ecs_alb_service_task.service_name}"
+  cluster_name = "${var.ecs_cluster_name}"
+}
+
+locals {
+  cpu_utilization_high_alarm_actions    = "${var.autoscaling_enabled == "true" && var.autoscaling_dimension == "cpu" ? module.autoscaling.scale_up_policy_arn : ""}"
+  cpu_utilization_low_alarm_actions     = "${var.autoscaling_enabled == "true" && var.autoscaling_dimension == "cpu" ? module.autoscaling.scale_down_policy_arn : ""}"
+  memory_utilization_high_alarm_actions = "${var.autoscaling_enabled == "true" && var.autoscaling_dimension == "memory" ? module.autoscaling.scale_up_policy_arn : ""}"
+  memory_utilization_low_alarm_actions  = "${var.autoscaling_enabled == "true" && var.autoscaling_dimension == "memory" ? module.autoscaling.scale_down_policy_arn : ""}"
+}
+
 module "ecs_alarms" {
   source     = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms.git?ref=tags/0.4.0"
   name       = "${var.name}"
@@ -101,25 +118,25 @@ module "ecs_alarms" {
   cpu_utilization_high_threshold          = "${var.ecs_alarms_cpu_utilization_high_threshold}"
   cpu_utilization_high_evaluation_periods = "${var.ecs_alarms_cpu_utilization_high_evaluation_periods}"
   cpu_utilization_high_period             = "${var.ecs_alarms_cpu_utilization_high_period}"
-  cpu_utilization_high_alarm_actions      = "${var.ecs_alarms_cpu_utilization_high_alarm_actions}"
+  cpu_utilization_high_alarm_actions      = "${compact(concat(var.ecs_alarms_cpu_utilization_high_alarm_actions, list(local.cpu_utilization_high_alarm_actions)))}"
   cpu_utilization_high_ok_actions         = "${var.ecs_alarms_cpu_utilization_high_ok_actions}"
 
   cpu_utilization_low_threshold          = "${var.ecs_alarms_cpu_utilization_low_threshold}"
   cpu_utilization_low_evaluation_periods = "${var.ecs_alarms_cpu_utilization_low_evaluation_periods}"
   cpu_utilization_low_period             = "${var.ecs_alarms_cpu_utilization_low_period}"
-  cpu_utilization_low_alarm_actions      = "${var.ecs_alarms_cpu_utilization_low_alarm_actions}"
+  cpu_utilization_low_alarm_actions      = "${compact(concat(var.ecs_alarms_cpu_utilization_low_alarm_actions, list(local.cpu_utilization_low_alarm_actions)))}"
   cpu_utilization_low_ok_actions         = "${var.ecs_alarms_cpu_utilization_low_ok_actions}"
 
   memory_utilization_high_threshold          = "${var.ecs_alarms_memory_utilization_high_threshold}"
   memory_utilization_high_evaluation_periods = "${var.ecs_alarms_memory_utilization_high_evaluation_periods}"
   memory_utilization_high_period             = "${var.ecs_alarms_memory_utilization_high_period}"
-  memory_utilization_high_alarm_actions      = "${var.ecs_alarms_memory_utilization_high_alarm_actions}"
+  memory_utilization_high_alarm_actions      = "${compact(concat(var.ecs_alarms_memory_utilization_high_alarm_actions, list(local.memory_utilization_high_alarm_actions)))}"
   memory_utilization_high_ok_actions         = "${var.ecs_alarms_memory_utilization_high_ok_actions}"
 
   memory_utilization_low_threshold          = "${var.ecs_alarms_memory_utilization_low_threshold}"
   memory_utilization_low_evaluation_periods = "${var.ecs_alarms_memory_utilization_low_evaluation_periods}"
   memory_utilization_low_period             = "${var.ecs_alarms_memory_utilization_low_period}"
-  memory_utilization_low_alarm_actions      = "${var.ecs_alarms_memory_utilization_low_alarm_actions}"
+  memory_utilization_low_alarm_actions      = "${compact(concat(var.ecs_alarms_memory_utilization_low_alarm_actions, list(local.memory_utilization_low_alarm_actions)))}"
   memory_utilization_low_ok_actions         = "${var.ecs_alarms_memory_utilization_low_ok_actions}"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ module "ecs_codepipeline" {
 
 module "autoscaling" {
   enabled      = "${var.autoscaling_enabled}"
-  source       = "../terraform-aws-ecs-cloudwatch-autoscaling"
+  source       = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=init"
   name         = "${var.name}"
   namespace    = "${var.namespace}"
   stage        = "${var.stage}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,18 @@
+output "scale_down_policy_arn" {
+  description = "Autoscaling scale up policy ARN"
+  value       = "${module.autoscaling.scale_down_policy_arn}"
+}
+
+output "scale_up_policy_arn" {
+  description = "Autoscaling scale up policy ARN"
+  value       = "${module.autoscaling.scale_up_policy_arn}"
+}
+
+output "service_name" {
+  description = "ECS Service Name"
+  value       = "${module.ecs_alb_service_task.service_name}"
+}
+
 output "task_role_arn" {
   description = "ECS Task role ARN"
   value       = "${module.ecs_alb_service_task.task_role_arn}"

--- a/variables.tf
+++ b/variables.tf
@@ -353,3 +353,51 @@ variable "branch" {
   description = "Branch of the GitHub repository, e.g. master"
   default     = ""
 }
+
+variable "autoscaling_enabled" {
+  type        = "string"
+  description = "A boolean to enable/disable Autoscaling policy for ECS Service."
+  default     = "false"
+}
+
+variable "autoscaling_dimension" {
+  type        = "string"
+  description = "Dimension to autoscale on (valid options: cpu, memory)"
+  default     = "memory"
+}
+
+variable "autoscaling_min_capacity" {
+  type        = "string"
+  description = "Minimum number of running instances of a Service."
+  default     = "1"
+}
+
+variable "autoscaling_max_capacity" {
+  type        = "string"
+  description = "Maximum number of running instances of a Service."
+  default     = "2"
+}
+
+variable "autoscaling_scale_up_adjustment" {
+  type        = "string"
+  description = "Scaling adjustment to make during scale up event."
+  default     = "1"
+}
+
+variable "autoscaling_scale_up_cooldown" {
+  type        = "string"
+  description = "Period (in seconds) to wait between scale up events."
+  default     = "60"
+}
+
+variable "autoscaling_scale_down_adjustment" {
+  type        = "string"
+  description = "Scaling adjustment to make during scale down event."
+  default     = "-1"
+}
+
+variable "autoscaling_scale_down_cooldown" {
+  type        = "string"
+  description = "Period (in seconds) to wait between scale down events."
+  default     = "300"
+}


### PR DESCRIPTION
## what
Add autoscaling module.

## why
Allow for optional autoscaling of ECS service on CPU or Memory. Also add outputs to the autoscaling policies for custom alarm triggers.