### PR TITLE
Adding build image variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Available targets:
 | aws_logs_region | The region for the AWS Cloudwatch Logs group. | string | - | yes |
 | badge_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge_url attribute when enabled. | string | `false` | no |
 | branch | Branch of the GitHub repository, e.g. master | string | `` | no |
+| build_image | Docker image for build environment, _e.g._ `aws/codebuild/docker:docker:17.09.0` | string | `aws/codebuild/docker:17.09.0` | no |
 | build_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. | string | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -31,6 +31,7 @@
 | aws_logs_region | The region for the AWS Cloudwatch Logs group. | string | - | yes |
 | badge_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge_url attribute when enabled. | string | `false` | no |
 | branch | Branch of the GitHub repository, e.g. master | string | `` | no |
+| build_image | Docker image for build environment, _e.g._ `aws/codebuild/docker:docker:17.09.0` | string | `aws/codebuild/docker:17.09.0` | no |
 | build_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed. | string | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |

--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ module "ecs_codepipeline" {
   repo_name             = "${var.repo_name}"
   branch                = "${var.branch}"
   badge_enabled         = "${var.badge_enabled}"
+  build_image           = "${var.build_image}"
   build_timeout         = "${var.build_timeout}"
   buildspec             = "${var.buildspec}"
   image_repo_name       = "${module.ecr.repository_name}"

--- a/variables.tf
+++ b/variables.tf
@@ -418,6 +418,11 @@ variable "badge_enabled" {
   description = "Generates a publicly-accessible URL for the projects build badge. Available as badge_url attribute when enabled."
 }
 
+variable "build_image" {
+  default     = "aws/codebuild/docker:17.09.0"
+  description = "Docker image for build environment, _e.g._ `aws/codebuild/docker:docker:17.09.0`"
+}
+
 variable "build_timeout" {
   type        = "string"
   default     = "60"


### PR DESCRIPTION
One worrisome aspect about this pattern: we have duplicate defaults in both `terraform-aws-ecs-web-app` and `terraform-aws-codepipeline`. E.g. if the default docker image goes from `aws/codebuild/docker:docker:17.09.0` to `aws/codebuild/docker:docker:17.10.0`, we would have to update both repos.

Not sure if there's a better pattern for this. Maybe we simply make the default `aws/codebuild/docker:docker:latest` or something?