### PR TITLE
Add `hosts` and `paths` with and without authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,13 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_arn_suffix | ARN suffix of the ALB for the Target Group | string | `` | no |
+| alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_ingress_healthcheck_path | The path of the healthcheck which the ALB checks | string | `/` | no |
-| alb_ingress_hosts | Hosts to match in Hosts header, at least one of hosts or paths must be set | list | `<list>` | no |
-| alb_ingress_listener_priority | Priority of the listeners, a number between 1 - 50000 (1 is highest priority) | string | `1000` | no |
-| alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
+| alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `1000` | no |
+| alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_name | Name of the ALB for the Target Group | string | `` | no |
 | alb_target_group_alarms_3xx_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service | string | `25` | no |
 | alb_target_group_alarms_4xx_threshold | The maximum number of 4XX HTTPCodes in a given period for ECS Service | string | `25` | no |
@@ -116,8 +119,7 @@ Available targets:
 | alb_target_group_alarms_response_time_threshold | The maximum ALB Target Group response time | string | `0.5` | no |
 | alb_target_group_arn | Pass target group down to module | string | `` | no |
 | attributes | List of attributes to add to label | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
-| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
 | autoscaling_dimension | Dimension to autoscale on (valid options: cpu, memory) | string | `memory` | no |
 | autoscaling_enabled | A boolean to enable/disable Autoscaling policy for ECS Service | string | `false` | no |
 | autoscaling_max_capacity | Maximum number of running instances of a Service | string | `2` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,10 +3,13 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | alb_arn_suffix | ARN suffix of the ALB for the Target Group | string | `` | no |
+| alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_ingress_healthcheck_path | The path of the healthcheck which the ALB checks | string | `/` | no |
-| alb_ingress_hosts | Hosts to match in Hosts header, at least one of hosts or paths must be set | list | `<list>` | no |
-| alb_ingress_listener_priority | Priority of the listeners, a number between 1 - 50000 (1 is highest priority) | string | `1000` | no |
-| alb_ingress_paths | Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set | list | `<list>` | no |
+| alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
+| alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `1000` | no |
+| alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_name | Name of the ALB for the Target Group | string | `` | no |
 | alb_target_group_alarms_3xx_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service | string | `25` | no |
 | alb_target_group_alarms_4xx_threshold | The maximum number of 4XX HTTPCodes in a given period for ECS Service | string | `25` | no |
@@ -20,8 +23,7 @@
 | alb_target_group_alarms_response_time_threshold | The maximum ALB Target Group response time | string | `0.5` | no |
 | alb_target_group_arn | Pass target group down to module | string | `` | no |
 | attributes | List of attributes to add to label | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true` | map | `<map>` | no |
-| authentication_enabled | Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC | string | `false` | no |
+| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
 | autoscaling_dimension | Dimension to autoscale on (valid options: cpu, memory) | string | `memory` | no |
 | autoscaling_enabled | A boolean to enable/disable Autoscaling policy for ECS Service | string | `false` | no |
 | autoscaling_max_capacity | Maximum number of running instances of a Service | string | `2` | no |

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -96,11 +96,11 @@ module "web_app" {
     "protocol"      = "tcp"
   }]
 
-  codepipeline_enabled = "true"
-  webhook_enabled      = "true"
+  codepipeline_enabled = "false"
+  webhook_enabled      = "false"
   badge_enabled        = "false"
-  ecs_alarms_enabled   = "true"
-  autoscaling_enabled  = "true"
+  ecs_alarms_enabled   = "false"
+  autoscaling_enabled  = "false"
 
   autoscaling_dimension             = "cpu"
   autoscaling_min_capacity          = 1
@@ -127,19 +127,19 @@ module "web_app" {
   alb_arn_suffix = "${module.alb.alb_arn_suffix}"
   alb_name       = "${module.alb.alb_name}"
 
+  alb_ingress_healthcheck_path = "/"
+
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
   listener_arns       = ["${module.alb.https_listener_arn}"]
   listener_arns_count = 1
 
-  # Unauthenticated paths (have higher priority than the authenticated paths)
+  # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
   alb_ingress_listener_unauthenticated_priority = "50"
 
   # Authenticated paths
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
-
-  alb_ingress_healthcheck_path = "/"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -116,10 +116,6 @@ module "web_app" {
   ecs_security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   ecs_private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
 
-  alb_ingress_healthcheck_path  = "/"
-  alb_ingress_paths             = ["/*"]
-  alb_ingress_listener_priority = "100"
-
   alb_target_group_alarms_enabled                 = "true"
   alb_target_group_alarms_3xx_threshold           = "25"
   alb_target_group_alarms_4xx_threshold           = "25"
@@ -135,7 +131,15 @@ module "web_app" {
   listener_arns       = ["${module.alb.https_listener_arn}"]
   listener_arns_count = 1
 
-  authentication_enabled = "true"
+  # Unauthenticated paths (have higher priority than the authenticated paths)
+  alb_ingress_unauthenticated_paths             = ["/events"]
+  alb_ingress_listener_unauthenticated_priority = "50"
+
+  # Authenticated paths
+  alb_ingress_authenticated_paths             = ["/*"]
+  alb_ingress_listener_authenticated_priority = "100"
+
+  alb_ingress_healthcheck_path = "/"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_cognito_authentication/variables.tf
+++ b/examples/with_cognito_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {
@@ -40,15 +40,15 @@ variable "region" {
   default     = "us-west-2"
 }
 
-variable "certificate_arn" {
-  type        = "string"
-  description = "SSL certificate ARN for ALB HTTPS endpoints"
-}
-
 variable "default_container_image" {
   type        = "string"
   description = "The default container image to use in container definition"
   default     = "nginxdemos/hello:latest"
+}
+
+variable "certificate_arn" {
+  type        = "string"
+  description = "SSL certificate ARN for ALB HTTPS endpoints"
 }
 
 variable "cognito_user_pool_arn" {
@@ -63,5 +63,5 @@ variable "cognito_user_pool_client_id" {
 
 variable "cognito_user_pool_domain" {
   type        = "string"
-  description = "Cognito User Pool domain"
+  description = "Cognito User Pool Domain"
 }

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -96,11 +96,11 @@ module "web_app" {
     "protocol"      = "tcp"
   }]
 
-  codepipeline_enabled = "true"
-  webhook_enabled      = "true"
+  codepipeline_enabled = "false"
+  webhook_enabled      = "false"
   badge_enabled        = "false"
-  ecs_alarms_enabled   = "true"
-  autoscaling_enabled  = "true"
+  ecs_alarms_enabled   = "false"
+  autoscaling_enabled  = "false"
 
   autoscaling_dimension             = "cpu"
   autoscaling_min_capacity          = 1
@@ -127,19 +127,19 @@ module "web_app" {
   alb_arn_suffix = "${module.alb.alb_arn_suffix}"
   alb_name       = "${module.alb.alb_name}"
 
+  alb_ingress_healthcheck_path = "/"
+
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
   listener_arns       = ["${module.alb.https_listener_arn}"]
   listener_arns_count = 1
 
-  # Unauthenticated paths (have higher priority than the authenticated paths)
+  # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
   alb_ingress_listener_unauthenticated_priority = "50"
 
   # Authenticated paths
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
-
-  alb_ingress_healthcheck_path = "/"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -116,10 +116,6 @@ module "web_app" {
   ecs_security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   ecs_private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
 
-  alb_ingress_healthcheck_path  = "/"
-  alb_ingress_paths             = ["/*"]
-  alb_ingress_listener_priority = "100"
-
   alb_target_group_alarms_enabled                 = "true"
   alb_target_group_alarms_3xx_threshold           = "25"
   alb_target_group_alarms_4xx_threshold           = "25"
@@ -135,7 +131,15 @@ module "web_app" {
   listener_arns       = ["${module.alb.https_listener_arn}"]
   listener_arns_count = 1
 
-  authentication_enabled = "true"
+  # Unauthenticated paths (have higher priority than the authenticated paths)
+  alb_ingress_unauthenticated_paths             = ["/events"]
+  alb_ingress_listener_unauthenticated_priority = "50"
+
+  # Authenticated paths
+  alb_ingress_authenticated_paths             = ["/*"]
+  alb_ingress_listener_authenticated_priority = "100"
+
+  alb_ingress_healthcheck_path = "/"
 
   # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
   authentication_action = {

--- a/examples/with_google_oidc_authentication/variables.tf
+++ b/examples/with_google_oidc_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {
@@ -40,6 +40,12 @@ variable "region" {
   default     = "us-west-2"
 }
 
+variable "default_container_image" {
+  type        = "string"
+  description = "The default container image to use in container definition"
+  default     = "nginxdemos/hello:latest"
+}
+
 variable "certificate_arn" {
   type        = "string"
   description = "SSL certificate ARN for ALB HTTPS endpoints"
@@ -53,10 +59,4 @@ variable "google_oidc_client_id" {
 variable "google_oidc_client_secret" {
   type        = "string"
   description = "Google OIDC Client Secret. Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials"
-}
-
-variable "default_container_image" {
-  type        = "string"
-  description = "The default container image to use in container definition"
-  default     = "nginxdemos/hello:latest"
 }

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -96,11 +96,11 @@ module "web_app" {
     "protocol"      = "tcp"
   }]
 
-  codepipeline_enabled = "true"
-  webhook_enabled      = "true"
+  codepipeline_enabled = "false"
+  webhook_enabled      = "false"
   badge_enabled        = "false"
-  ecs_alarms_enabled   = "true"
-  autoscaling_enabled  = "true"
+  ecs_alarms_enabled   = "false"
+  autoscaling_enabled  = "false"
 
   autoscaling_dimension             = "cpu"
   autoscaling_min_capacity          = 1
@@ -127,6 +127,8 @@ module "web_app" {
   alb_arn_suffix = "${module.alb.alb_arn_suffix}"
   alb_name       = "${module.alb.alb_name}"
 
+  alb_ingress_healthcheck_path = "/"
+
   # Without authentication, both HTTP and HTTPS endpoints are supported
   listener_arns       = ["${module.alb.listener_arns}"]
   listener_arns_count = 2
@@ -134,6 +136,4 @@ module "web_app" {
   # All paths are unauthenticated
   alb_ingress_unauthenticated_paths             = ["/*"]
   alb_ingress_listener_unauthenticated_priority = "100"
-
-  alb_ingress_healthcheck_path = "/"
 }

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -116,10 +116,6 @@ module "web_app" {
   ecs_security_group_ids = ["${module.vpc.vpc_default_security_group_id}"]
   ecs_private_subnet_ids = ["${module.subnets.private_subnet_ids}"]
 
-  alb_ingress_healthcheck_path  = "/"
-  alb_ingress_paths             = ["/*"]
-  alb_ingress_listener_priority = "100"
-
   alb_target_group_alarms_enabled                 = "true"
   alb_target_group_alarms_3xx_threshold           = "25"
   alb_target_group_alarms_4xx_threshold           = "25"
@@ -131,8 +127,13 @@ module "web_app" {
   alb_arn_suffix = "${module.alb.alb_arn_suffix}"
   alb_name       = "${module.alb.alb_name}"
 
+  # Without authentication, both HTTP and HTTPS endpoints are supported
   listener_arns       = ["${module.alb.listener_arns}"]
-  listener_arns_count = 1
+  listener_arns_count = 2
 
-  authentication_enabled = "false"
+  # All paths are unauthenticated
+  alb_ingress_unauthenticated_paths             = ["/*"]
+  alb_ingress_listener_unauthenticated_priority = "100"
+
+  alb_ingress_healthcheck_path = "/"
 }

--- a/examples/without_authentication/variables.tf
+++ b/examples/without_authentication/variables.tf
@@ -1,7 +1,7 @@
 variable "namespace" {
   type        = "string"
   description = "Namespace (e.g. `cp` or `cloudposse`)"
-  default     = "ex2"
+  default     = "eg"
 }
 
 variable "stage" {

--- a/main.tf
+++ b/main.tf
@@ -20,21 +20,23 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "alb_ingress" {
-  source                 = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.4.0"
-  name                   = "${var.name}"
-  namespace              = "${var.namespace}"
-  stage                  = "${var.stage}"
-  attributes             = "${var.attributes}"
-  vpc_id                 = "${var.vpc_id}"
-  listener_arns          = "${var.listener_arns}"
-  listener_arns_count    = "${var.listener_arns_count}"
-  health_check_path      = "${var.alb_ingress_healthcheck_path}"
-  paths                  = ["${var.alb_ingress_paths}"]
-  priority               = "${var.alb_ingress_listener_priority}"
-  hosts                  = ["${var.alb_ingress_hosts}"]
-  port                   = "${var.container_port}"
-  authentication_enabled = "${var.authentication_enabled}"
-  authentication_action  = "${var.authentication_action}"
+  source                   = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.5.0"
+  name                     = "${var.name}"
+  namespace                = "${var.namespace}"
+  stage                    = "${var.stage}"
+  attributes               = "${var.attributes}"
+  vpc_id                   = "${var.vpc_id}"
+  listener_arns            = "${var.listener_arns}"
+  listener_arns_count      = "${var.listener_arns_count}"
+  port                     = "${var.container_port}"
+  health_check_path        = "${var.alb_ingress_healthcheck_path}"
+  authenticated_paths      = ["${var.alb_ingress_authenticated_paths}"]
+  unauthenticated_paths    = ["${var.alb_ingress_unauthenticated_paths}"]
+  authenticated_hosts      = ["${var.alb_ingress_authenticated_hosts}"]
+  unauthenticated_hosts    = ["${var.alb_ingress_unauthenticated_hosts}"]
+  authenticated_priority   = "${var.alb_ingress_listener_authenticated_priority}"
+  unauthenticated_priority = "${var.alb_ingress_listener_unauthenticated_priority}"
+  authentication_action    = "${var.authentication_action}"
 }
 
 module "container_definition" {
@@ -78,7 +80,7 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled               = "${var.codepipeline_enabled}"
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.6.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.6.1"
   name                  = "${var.name}"
   namespace             = "${var.namespace}"
   stage                 = "${var.stage}"

--- a/variables.tf
+++ b/variables.tf
@@ -204,22 +204,40 @@ variable "alb_ingress_healthcheck_path" {
   default     = "/"
 }
 
-variable "alb_ingress_hosts" {
-  type        = "list"
-  default     = []
-  description = "Hosts to match in Hosts header, at least one of hosts or paths must be set"
-}
-
-variable "alb_ingress_paths" {
-  type        = "list"
-  default     = []
-  description = "Path pattern to match (a maximum of 1 can be defined), at least one of hosts or paths must be set"
-}
-
-variable "alb_ingress_listener_priority" {
+variable "alb_ingress_listener_unauthenticated_priority" {
   type        = "string"
   default     = "1000"
-  description = "Priority of the listeners, a number between 1 - 50000 (1 is highest priority)"
+  description = "The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "alb_ingress_listener_authenticated_priority" {
+  type        = "string"
+  default     = "300"
+  description = "The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority"
+}
+
+variable "alb_ingress_unauthenticated_hosts" {
+  type        = "list"
+  default     = []
+  description = "Unauthenticated hosts to match in Hosts header"
+}
+
+variable "alb_ingress_authenticated_hosts" {
+  type        = "list"
+  default     = []
+  description = "Authenticated hosts to match in Hosts header"
+}
+
+variable "alb_ingress_unauthenticated_paths" {
+  type        = "list"
+  default     = []
+  description = "Unauthenticated path pattern to match (a maximum of 1 can be defined)"
+}
+
+variable "alb_ingress_authenticated_paths" {
+  type        = "list"
+  default     = []
+  description = "Authenticated path pattern to match (a maximum of 1 can be defined)"
 }
 
 variable "vpc_id" {
@@ -522,14 +540,8 @@ variable "webhook_filter_match_equals" {
   default     = "refs/heads/{Branch}"
 }
 
-variable "authentication_enabled" {
-  type        = "string"
-  default     = "false"
-  description = "Whether to enable authentication action for ALB listener to authenticate users with Cognito or OIDC"
-}
-
 variable "authentication_action" {
   type        = "map"
   default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `authentication_enabled=true`"
+  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided"
 }


### PR DESCRIPTION
## what
* Add `hosts` and `paths` with and without authentication
* Update examples

## why
* Some applications deployed on ECS, e.g. `atlantis`,  require authentication on all paths except for the webhook callback URLs (e..g. `/events`). This update allows specifying separate paths and hosts without authentication and with authentication (to which the authentication action will be assigned) with different priorities