### PR TITLE
Fix authentication action. Don't use `map` variable for authentication action

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ Module usage examples:
 ```
 module "default-backend-web-app" {
   source                                          = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
-  name                                            = "appname"
   namespace                                       = "eg"
   stage                                           = "testing"
+  name                                            = "appname"
   vpc_id                                          = "${module.vpc.vpc_id}"
   alb_ingress_unauthenticated_listener_arns       = "${module.alb.listener_arns}"
   alb_ingress_unauthenticated_listener_arns_count = "1"

--- a/README.yaml
+++ b/README.yaml
@@ -80,9 +80,9 @@ usage: |-
   ```
   module "default-backend-web-app" {
     source                                          = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
-    name                                            = "appname"
     namespace                                       = "eg"
     stage                                           = "testing"
+    name                                            = "appname"
     vpc_id                                          = "${module.vpc.vpc_id}"
     alb_ingress_unauthenticated_listener_arns       = "${module.alb.listener_arns}"
     alb_ingress_unauthenticated_listener_arns_count = "1"

--- a/README.yaml
+++ b/README.yaml
@@ -79,31 +79,32 @@ usage: |-
 
   ```
   module "default-backend-web-app" {
-    source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
-    name                         = "appname"
-    namespace                    = "eg"
-    stage                        = "testing"
-    vpc_id                       = "${module.vpc.vpc_id}"
-    listener_arns                = "${module.alb.listener_arns}"
-    listener_arns_count          = "1"
-    aws_logs_region              = "us-west-2"
-    ecs_cluster_arn              = "${aws_ecs_cluster.default.arn}"
-    ecs_cluster_name             = "${aws_ecs_cluster.default.name}"
-    ecs_security_group_ids       = ["${module.vpc.vpc_default_security_group_id}"]
-    ecs_private_subnet_ids       = ["${module.subnets.private_subnet_ids}"]
-    alb_ingress_healthcheck_path = "/healthz"
-    alb_ingress_paths            = ["/*"]
-    codepipeline_enabled         = "false"
+    source                                          = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
+    name                                            = "appname"
+    namespace                                       = "eg"
+    stage                                           = "testing"
+    vpc_id                                          = "${module.vpc.vpc_id}"
+    alb_ingress_unauthenticated_listener_arns       = "${module.alb.listener_arns}"
+    alb_ingress_unauthenticated_listener_arns_count = "1"
+    aws_logs_region                                 = "us-west-2"
+    ecs_cluster_arn                                 = "${aws_ecs_cluster.default.arn}"
+    ecs_cluster_name                                = "${aws_ecs_cluster.default.name}"
+    ecs_security_group_ids                          = ["${module.vpc.vpc_default_security_group_id}"]
+    ecs_private_subnet_ids                          = ["${module.subnets.private_subnet_ids}"]
+    alb_ingress_healthcheck_path                    = "/healthz"
+    alb_ingress_unauthenticated_paths               = ["/*"]
+    codepipeline_enabled                            = "false"
+
     environment = [
-        {
-          name = "COOKIE"
-          value = "cookiemonster"
-        },
-        {
-          name = "PORT"
-          value = "80"
-        }
-      ]
+      {
+        name = "COOKIE"
+        value = "cookiemonster"
+      },
+      {
+        name = "PORT"
+        value = "80"
+      }
+    ]
   }
   ```
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,11 +4,15 @@
 |------|-------------|:----:|:-----:|:-----:|
 | alb_arn_suffix | ARN suffix of the ALB for the Target Group | string | `` | no |
 | alb_ingress_authenticated_hosts | Authenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_authenticated_listener_arns_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_authenticated_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_ingress_healthcheck_path | The path of the healthcheck which the ALB checks | string | `/` | no |
 | alb_ingress_listener_authenticated_priority | The priority for the rules with authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_unauthenticated_priority` since a listener can't have multiple rules with the same priority | string | `300` | no |
 | alb_ingress_listener_unauthenticated_priority | The priority for the rules without authentication, between 1 and 50000 (1 being highest priority). Must be different from `alb_ingress_listener_authenticated_priority` since a listener can't have multiple rules with the same priority | string | `1000` | no |
 | alb_ingress_unauthenticated_hosts | Unauthenticated hosts to match in Hosts header | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | list | `<list>` | no |
+| alb_ingress_unauthenticated_listener_arns_count | The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | string | `0` | no |
 | alb_ingress_unauthenticated_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | list | `<list>` | no |
 | alb_name | Name of the ALB for the Target Group | string | `` | no |
 | alb_target_group_alarms_3xx_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service | string | `25` | no |
@@ -23,7 +27,16 @@
 | alb_target_group_alarms_response_time_threshold | The maximum ALB Target Group response time | string | `0.5` | no |
 | alb_target_group_arn | Pass target group down to module | string | `` | no |
 | attributes | List of attributes to add to label | list | `<list>` | no |
-| authentication_action | Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided | map | `<map>` | no |
+| authentication_cognito_user_pool_arn | Cognito User Pool ARN | string | `` | no |
+| authentication_cognito_user_pool_client_id | Cognito User Pool Client ID | string | `` | no |
+| authentication_cognito_user_pool_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | string | `` | no |
+| authentication_oidc_authorization_endpoint | OIDC Authorization Endpoint | string | `` | no |
+| authentication_oidc_client_id | OIDC Client ID | string | `` | no |
+| authentication_oidc_client_secret | OIDC Client Secret | string | `` | no |
+| authentication_oidc_issuer | OIDC Issuer | string | `` | no |
+| authentication_oidc_token_endpoint | OIDC Token Endpoint | string | `` | no |
+| authentication_oidc_user_info_endpoint | OIDC User Info Endpoint | string | `` | no |
+| authentication_type | Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE` | string | `NONE` | no |
 | autoscaling_dimension | Dimension to autoscale on (valid options: cpu, memory) | string | `memory` | no |
 | autoscaling_enabled | A boolean to enable/disable Autoscaling policy for ECS Service | string | `false` | no |
 | autoscaling_max_capacity | Maximum number of running instances of a Service | string | `2` | no |
@@ -78,8 +91,6 @@
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | host_port | The port number to bind container_port to on the host | string | `` | no |
 | launch_type | The ECS launch type (valid options: FARGATE or EC2) | string | `FARGATE` | no |
-| listener_arns | List of ALB Listener ARNs for the ECS service | list | - | yes |
-| listener_arns_count | Number of elements in list of ALB Listener ARNs for the ECS service | string | - | yes |
 | name | Name (unique identifier for app or service) | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | - | yes |
 | poll_source_changes | Periodically check the location of your source content and run the pipeline if changes are detected | string | `false` | no |

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -130,8 +130,8 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  listener_arns       = ["${module.alb.https_listener_arn}"]
-  listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_ingress_authenticated_listener_arns_count = 1
 
   # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
@@ -141,14 +141,8 @@ module "web_app" {
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
 
-  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
-  authentication_action = {
-    type = "authenticate-cognito"
-
-    authenticate_cognito = [{
-      user_pool_arn       = "${var.cognito_user_pool_arn}"
-      user_pool_client_id = "${var.cognito_user_pool_client_id}"
-      user_pool_domain    = "${var.cognito_user_pool_domain}"
-    }]
-  }
+  authentication_type                        = "COGNITO"
+  authentication_cognito_user_pool_arn       = "${var.cognito_user_pool_arn}"
+  authentication_cognito_user_pool_client_id = "${var.cognito_user_pool_client_id}"
+  authentication_cognito_user_pool_domain    = "${var.cognito_user_pool_domain}"
 }

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -130,8 +130,8 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  listener_arns       = ["${module.alb.https_listener_arn}"]
-  listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns       = ["${module.alb.https_listener_arn}"]
+  alb_ingress_authenticated_listener_arns_count = 1
 
   # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]
@@ -141,20 +141,11 @@ module "web_app" {
   alb_ingress_authenticated_paths             = ["/*"]
   alb_ingress_listener_authenticated_priority = "100"
 
-  # https://www.terraform.io/docs/providers/aws/r/lb_listener_rule.html
-  authentication_action = {
-    type = "authenticate-oidc"
-
-    authenticate_oidc = [{
-      # Use this URL to create a Google OAuth 2.0 Client and obtain the Client ID and Client Secret: https://console.developers.google.com/apis/credentials
-      client_id     = "${var.google_oidc_client_id}"
-      client_secret = "${var.google_oidc_client_secret}"
-
-      # Use this URL to get Google Auth endpoints: https://accounts.google.com/.well-known/openid-configuration
-      issuer                 = "https://accounts.google.com"
-      authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
-      token_endpoint         = "https://oauth2.googleapis.com/token"
-      user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
-    }]
-  }
+  authentication_type                        = "OIDC"
+  authentication_oidc_client_id              = "${var.google_oidc_client_id}"
+  authentication_oidc_client_secret          = "${var.google_oidc_client_secret}"
+  authentication_oidc_issuer                 = "https://accounts.google.com"
+  authentication_oidc_authorization_endpoint = "https://accounts.google.com/o/oauth2/v2/auth"
+  authentication_oidc_token_endpoint         = "https://oauth2.googleapis.com/token"
+  authentication_oidc_user_info_endpoint     = "https://openidconnect.googleapis.com/v1/userinfo"
 }

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -130,8 +130,8 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # Without authentication, both HTTP and HTTPS endpoints are supported
-  listener_arns       = ["${module.alb.listener_arns}"]
-  listener_arns_count = 2
+  alb_ingress_unauthenticated_listener_arns       = ["${module.alb.listener_arns}"]
+  alb_ingress_unauthenticated_listener_arns_count = 2
 
   # All paths are unauthenticated
   alb_ingress_unauthenticated_paths             = ["/*"]

--- a/main.tf
+++ b/main.tf
@@ -21,23 +21,38 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "alb_ingress" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.5.0"
-  name                     = "${var.name}"
-  namespace                = "${var.namespace}"
-  stage                    = "${var.stage}"
-  attributes               = "${var.attributes}"
-  vpc_id                   = "${var.vpc_id}"
-  listener_arns            = "${var.listener_arns}"
-  listener_arns_count      = "${var.listener_arns_count}"
-  port                     = "${var.container_port}"
-  health_check_path        = "${var.alb_ingress_healthcheck_path}"
-  authenticated_paths      = ["${var.alb_ingress_authenticated_paths}"]
-  unauthenticated_paths    = ["${var.alb_ingress_unauthenticated_paths}"]
-  authenticated_hosts      = ["${var.alb_ingress_authenticated_hosts}"]
-  unauthenticated_hosts    = ["${var.alb_ingress_unauthenticated_hosts}"]
+  source            = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.6.0"
+  name              = "${var.name}"
+  namespace         = "${var.namespace}"
+  stage             = "${var.stage}"
+  attributes        = "${var.attributes}"
+  vpc_id            = "${var.vpc_id}"
+  port              = "${var.container_port}"
+  health_check_path = "${var.alb_ingress_healthcheck_path}"
+
+  authenticated_paths   = ["${var.alb_ingress_authenticated_paths}"]
+  unauthenticated_paths = ["${var.alb_ingress_unauthenticated_paths}"]
+  authenticated_hosts   = ["${var.alb_ingress_authenticated_hosts}"]
+  unauthenticated_hosts = ["${var.alb_ingress_unauthenticated_hosts}"]
+
   authenticated_priority   = "${var.alb_ingress_listener_authenticated_priority}"
   unauthenticated_priority = "${var.alb_ingress_listener_unauthenticated_priority}"
-  authentication_action    = "${var.authentication_action}"
+
+  unauthenticated_listener_arns       = "${var.alb_ingress_unauthenticated_listener_arns}"
+  unauthenticated_listener_arns_count = "${var.alb_ingress_unauthenticated_listener_arns_count}"
+  authenticated_listener_arns         = "${var.alb_ingress_authenticated_listener_arns}"
+  authenticated_listener_arns_count   = "${var.alb_ingress_authenticated_listener_arns_count}"
+
+  authentication_type                        = "${var.authentication_type}"
+  authentication_cognito_user_pool_arn       = "${var.authentication_cognito_user_pool_arn}"
+  authentication_cognito_user_pool_client_id = "${var.authentication_cognito_user_pool_client_id}"
+  authentication_cognito_user_pool_domain    = "${var.authentication_cognito_user_pool_domain}"
+  authentication_oidc_client_id              = "${var.authentication_oidc_client_id}"
+  authentication_oidc_client_secret          = "${var.authentication_oidc_client_secret}"
+  authentication_oidc_issuer                 = "${var.authentication_oidc_issuer}"
+  authentication_oidc_authorization_endpoint = "${var.authentication_oidc_authorization_endpoint}"
+  authentication_oidc_token_endpoint         = "${var.authentication_oidc_token_endpoint}"
+  authentication_oidc_user_info_endpoint     = "${var.authentication_oidc_user_info_endpoint}"
 }
 
 module "container_definition" {

--- a/variables.tf
+++ b/variables.tf
@@ -245,16 +245,6 @@ variable "vpc_id" {
   description = "The VPC ID where resources are created"
 }
 
-variable "listener_arns" {
-  type        = "list"
-  description = "List of ALB Listener ARNs for the ECS service"
-}
-
-variable "listener_arns_count" {
-  type        = "string"
-  description = "Number of elements in list of ALB Listener ARNs for the ECS service"
-}
-
 variable "aws_logs_region" {
   type        = "string"
   description = "The region for the AWS Cloudwatch Logs group"
@@ -540,8 +530,86 @@ variable "webhook_filter_match_equals" {
   default     = "refs/heads/{Branch}"
 }
 
-variable "authentication_action" {
-  type        = "map"
-  default     = {}
-  description = "Authentication action to be placed in front of all other ALB listener actions to authenticate users with Cognito or OIDC. Required when `alb_ingress_authenticated_hosts` or `alb_ingress_authenticated_paths` are provided"
+variable "alb_ingress_unauthenticated_listener_arns" {
+  type        = "list"
+  default     = []
+  description = "A list of unauthenticated ALB listener ARNs to attach ALB listener rules to"
+}
+
+variable "alb_ingress_unauthenticated_listener_arns_count" {
+  type        = "string"
+  default     = "0"
+  description = "The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+}
+
+variable "alb_ingress_authenticated_listener_arns" {
+  type        = "list"
+  default     = []
+  description = "A list of authenticated ALB listener ARNs to attach ALB listener rules to"
+}
+
+variable "alb_ingress_authenticated_listener_arns_count" {
+  type        = "string"
+  default     = "0"
+  description = "The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
+}
+
+variable "authentication_type" {
+  type        = "string"
+  default     = "NONE"
+  description = "Authentication type. Supported values are `COGNITO`, `OIDC`, `NONE`"
+}
+
+variable "authentication_cognito_user_pool_arn" {
+  type        = "string"
+  description = "Cognito User Pool ARN"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_client_id" {
+  type        = "string"
+  description = "Cognito User Pool Client ID"
+  default     = ""
+}
+
+variable "authentication_cognito_user_pool_domain" {
+  type        = "string"
+  description = "Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com)"
+  default     = ""
+}
+
+variable "authentication_oidc_client_id" {
+  type        = "string"
+  description = "OIDC Client ID"
+  default     = ""
+}
+
+variable "authentication_oidc_client_secret" {
+  type        = "string"
+  description = "OIDC Client Secret"
+  default     = ""
+}
+
+variable "authentication_oidc_issuer" {
+  type        = "string"
+  description = "OIDC Issuer"
+  default     = ""
+}
+
+variable "authentication_oidc_authorization_endpoint" {
+  type        = "string"
+  description = "OIDC Authorization Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_token_endpoint" {
+  type        = "string"
+  description = "OIDC Token Endpoint"
+  default     = ""
+}
+
+variable "authentication_oidc_user_info_endpoint" {
+  type        = "string"
+  description = "OIDC User Info Endpoint"
+  default     = ""
 }


### PR DESCRIPTION
## what
* Fix authentication action
* Don't use `map` variable for authentication action

## why
* Using `authentication_action` variable as a `map` breaks when this module is used in a chain of calls from other modules
For example:
   * Providing `authentication_action` map from Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module C to Module B to `alb-ingress` - works
   * Providing `authentication_action` map from Module D to Module C to Module B to `alb-ingress` - breaks (in a way that is very difficult to understand and debug; the end result is that `alb-ingress` receives an empty or incomplete map)

