### PR TITLE
Bump `terraform-aws-ecs-codepipeline` version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,7 +96,7 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled               = "${var.codepipeline_enabled}"
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.6.1"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.7.0"
   name                  = "${var.name}"
   namespace             = "${var.namespace}"
   stage                 = "${var.stage}"


### PR DESCRIPTION
## what
* Bump `terraform-aws-ecs-codepipeline` version

## why
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/pull/23
* https://github.com/cloudposse/terraform-github-repository-webhooks/pull/8
