### PR TITLE
Add secrets variable and pass through to container_definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Available targets:
 | protocol | The protocol used for the port mapping. Options: `tcp` or `udp` | string | `tcp` | no |
 | repo_name | GitHub repository name of the application to be built and deployed to ECS | string | `` | no |
 | repo_owner | GitHub Organization or Username | string | `` | no |
+| secrets | The secrets for the task definition. This is a list of maps | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags | map | `<map>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -98,6 +98,7 @@
 | protocol | The protocol used for the port mapping. Options: `tcp` or `udp` | string | `tcp` | no |
 | repo_name | GitHub repository name of the application to be built and deployed to ECS | string | `` | no |
 | repo_owner | GitHub Organization or Username | string | `` | no |
+| secrets | The secrets for the task definition. This is a list of maps | list | `<list>` | no |
 | stage | Stage (e.g. `prod`, `dev`, `staging`) | string | - | yes |
 | tags | Map of key-value pairs to use for tags | map | `<map>` | no |
 | vpc_id | The VPC ID where resources are created | string | - | yes |

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,7 @@ module "container_definition" {
   healthcheck                  = "${var.healthcheck}"
   environment                  = "${var.environment}"
   port_mappings                = "${var.port_mappings}"
+  secrets                      = "${var.secrets}"
 
   log_options = {
     "awslogs-region"        = "${var.aws_logs_region}"

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "environment" {
   default     = []
 }
 
+variable "secrets" {
+  type        = "list"
+  description = "The secrets for the task definition. This is a list of maps"
+  default     = []
+}
+
 variable "protocol" {
   type        = "string"
   description = "The protocol used for the port mapping. Options: `tcp` or `udp`"


### PR DESCRIPTION
# What
Add `secrets` variable and pass value through to `container_definition` ([terraform-aws-ecs-container-definition](https://github.com/cloudposse/terraform-aws-ecs-container-definition/blob/master/variables.tf#L73)) module.

# Why
Without this, it's impossible to use this module with ECS's support for [injecting secrets](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/specifying-sensitive-data.html) into the container's environment from SSM Parameter store.