### PR TITLE
Bump `terraform-aws-ecs-codepipeline` version. Add `github_webhooks_token` and `codepipeline_s3_bucket_force_destroy` variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Available targets:
 | build_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | string | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |
+| codepipeline_s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | string | `false` | no |
 | container_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | string | `256` | no |
 | container_image | The default container image to use in container definition | string | `cloudposse/default-backend` | no |
 | container_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | string | `512` | no |
@@ -189,6 +190,7 @@ Available targets:
 | environment | The environment variables for the task definition. This is a list of maps | list | `<list>` | no |
 | github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | host_port | The port number to bind container_port to on the host | string | `` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -52,6 +52,7 @@
 | build_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | string | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | string | `` | no |
 | codepipeline_enabled | A boolean to enable/disable AWS Codepipeline and ECR | string | `true` | no |
+| codepipeline_s3_bucket_force_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | string | `false` | no |
 | container_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | string | `256` | no |
 | container_image | The default container image to use in container definition | string | `cloudposse/default-backend` | no |
 | container_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | string | `512` | no |
@@ -87,6 +88,7 @@
 | environment | The environment variables for the task definition. This is a list of maps | list | `<list>` | no |
 | github_oauth_token | GitHub Oauth Token with permissions to access private repositories | string | `` | no |
 | github_webhook_events | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | list | `<list>` | no |
+| github_webhooks_token | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | string | `` | no |
 | health_check_grace_period_seconds | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | string | `0` | no |
 | healthcheck | A map containing command (string), interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy, and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | map | `<map>` | no |
 | host_port | The port number to bind container_port to on the host | string | `` | no |

--- a/main.tf
+++ b/main.tf
@@ -97,12 +97,13 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled               = "${var.codepipeline_enabled}"
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.7.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.8.0"
   name                  = "${var.name}"
   namespace             = "${var.namespace}"
   stage                 = "${var.stage}"
   attributes            = "${var.attributes}"
   github_oauth_token    = "${var.github_oauth_token}"
+  github_webhooks_token = "${var.github_webhooks_token}"
   github_webhook_events = "${var.github_webhook_events}"
   repo_owner            = "${var.repo_owner}"
   repo_name             = "${var.repo_name}"
@@ -122,6 +123,8 @@ module "ecs_codepipeline" {
   webhook_authentication      = "${var.webhook_authentication}"
   webhook_filter_json_path    = "${var.webhook_filter_json_path}"
   webhook_filter_match_equals = "${var.webhook_filter_match_equals}"
+
+  s3_bucket_force_destroy = "${var.codepipeline_s3_bucket_force_destroy}"
 
   environment_variables = [{
     "name"  = "CONTAINER_NAME"

--- a/variables.tf
+++ b/variables.tf
@@ -409,6 +409,12 @@ variable "github_oauth_token" {
   default     = ""
 }
 
+variable "github_webhooks_token" {
+  type        = "string"
+  description = "GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
+  default     = ""
+}
+
 variable "github_webhook_events" {
   type        = "list"
   description = "A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/)"
@@ -618,4 +624,9 @@ variable "authentication_oidc_user_info_endpoint" {
   type        = "string"
   description = "OIDC User Info Endpoint"
   default     = ""
+}
+
+variable "codepipeline_s3_bucket_force_destroy" {
+  description = "A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error"
+  default     = false
 }


### PR DESCRIPTION
## what
* Bump `terraform-aws-ecs-codepipeline` version
* Add `github_webhooks_token` variable
* Add `codepipeline_s3_bucket_force_destroy` variable

## why
* Make GitHub token for creating webhooks optional. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable. Sourcing from the `GITHUB_TOKEN` environment variable is useful when the module is provisioned from `geodesic` or CI/CD that have access to the `GITHUB_TOKEN` environment variable, which in turn could be sourced from SSM using `chamber`

* `codepipeline_s3_bucket_force_destroy` is a boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error

## references
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/tag/0.8.0
* https://github.com/cloudposse/terraform-github-repository-webhooks/releases/tag/0.4.0
