### PR TITLE
Tags to ecs_alb_service_task

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -104,6 +104,7 @@ module "ecs_alb_service_task" {
   security_group_ids                = ["${var.ecs_security_group_ids}"]
   private_subnet_ids                = ["${var.ecs_private_subnet_ids}"]
   container_port                    = "${var.container_port}"
+  tags                              = "${var.tags}"
 }
 
 module "ecs_codepipeline" {


### PR DESCRIPTION
## What
* Added tags to `ecs_alb_service_task`

## Why
* I need to set tags for an ECS task definition from the module.