### PR TITLE
Add variable to control log group retention period

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,7 @@ Available targets:
 | init_containers | A list of additional init containers to start. The map contains the container_definition (JSON) and the main container's dependency condition (string) on the init container. The latter can be one of START, COMPLETE, SUCCESS or HEALTHY. | object | `<list>` | no |
 | launch_type | The ECS launch type (valid options: FARGATE or EC2) | string | `FARGATE` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `awslogs` | no |
+| log_retention_in_days | The number of days to retain logs for the log group | number | `null` | no |
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `null` | no |
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -273,6 +274,8 @@ Available targets:
 | alb_ingress_target_group_arn | ALB Target Group ARN |
 | alb_ingress_target_group_arn_suffix | ALB Target Group ARN suffix |
 | alb_ingress_target_group_name | ALB Target Group name |
+| cloudwatch_log_group_arn | Cloudwatch log group ARN |
+| cloudwatch_log_group_name | Cloudwatch log group name |
 | codebuild_badge_url | The URL of the build badge when badge_enabled is enabled |
 | codebuild_cache_bucket_arn | CodeBuild cache S3 bucket ARN |
 | codebuild_cache_bucket_name | CodeBuild cache S3 bucket name |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -95,6 +95,7 @@
 | init_containers | A list of additional init containers to start. The map contains the container_definition (JSON) and the main container's dependency condition (string) on the init container. The latter can be one of START, COMPLETE, SUCCESS or HEALTHY. | object | `<list>` | no |
 | launch_type | The ECS launch type (valid options: FARGATE or EC2) | string | `FARGATE` | no |
 | log_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | string | `awslogs` | no |
+| log_retention_in_days | The number of days to retain logs for the log group | number | `null` | no |
 | mount_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | object | `null` | no |
 | name | Name of the application | string | - | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | string | `` | no |
@@ -129,6 +130,8 @@
 | alb_ingress_target_group_arn | ALB Target Group ARN |
 | alb_ingress_target_group_arn_suffix | ALB Target Group ARN suffix |
 | alb_ingress_target_group_name | ALB Target Group name |
+| cloudwatch_log_group_arn | Cloudwatch log group ARN |
+| cloudwatch_log_group_name | Cloudwatch log group name |
 | codebuild_badge_url | The URL of the build badge when badge_enabled is enabled |
 | codebuild_cache_bucket_arn | CodeBuild cache S3 bucket ARN |
 | codebuild_cache_bucket_name | CodeBuild cache S3 bucket name |

--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,9 @@ module "ecr" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  name = module.default_label.id
-  tags = module.default_label.tags
+  name              = module.default_label.id
+  tags              = module.default_label.tags
+  retention_in_days = var.log_retention_in_days
 }
 
 module "alb_ingress" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -98,6 +98,16 @@ output "ecs_task_definition_revision" {
   value       = module.ecs_alb_service_task.task_definition_revision
 }
 
+output "cloudwatch_log_group_arn" {
+  description = "Cloudwatch log group ARN"
+  value       = aws_cloudwatch_log_group.app.arn
+}
+
+output "cloudwatch_log_group_name" {
+  description = "Cloudwatch log group name"
+  value       = aws_cloudwatch_log_group.app.name
+}
+
 output "codebuild_project_name" {
   description = "CodeBuild project name"
   value       = module.ecs_codepipeline.codebuild_project_name

--- a/variables.tf
+++ b/variables.tf
@@ -356,6 +356,12 @@ variable "aws_logs_region" {
   description = "The region for the AWS Cloudwatch Logs group"
 }
 
+variable "log_retention_in_days" {
+  type        = number
+  description = "The number of days to retain logs for the log group"
+  default     = null
+}
+
 variable "log_driver" {
   type        = string
   description = "The log driver to use for the container. If using Fargate launch type, only supported value is awslogs"


### PR DESCRIPTION
The default log retention period is infinite. This change exposes the retention period as a variable, and returns the log group ARN / name so that additional init containers can use the same underlying log group as the main container, if desired.