### PR TITLE
Override container definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ Available targets:
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |
 | container\_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
+| container\_definition | Override the main container\_definition | `string` | `[]` | no |
 | container\_image | The default container image to use in container definition | `string` | `"cloudposse/default-backend"` | no |
 | container\_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `512` | no |
 | container\_memory\_reservation | The amount of RAM (Soft Limit) to allow container to use in MB. This value must be less than `container_memory` if set | `number` | `128` | no |

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Available targets:
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |
 | container\_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
-| container\_definition | Override the main container\_definition | `string` | `[]` | no |
+| container\_definition | Override the main container\_definition | `string` | `""` | no |
 | container\_image | The default container image to use in container definition | `string` | `"cloudposse/default-backend"` | no |
 | container\_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `512` | no |
 | container\_memory\_reservation | The amount of RAM (Soft Limit) to allow container to use in MB. This value must be less than `container_memory` if set | `number` | `128` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -76,7 +76,7 @@
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |
 | container\_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
-| container\_definition | Override the main container\_definition | `string` | `[]` | no |
+| container\_definition | Override the main container\_definition | `string` | `""` | no |
 | container\_image | The default container image to use in container definition | `string` | `"cloudposse/default-backend"` | no |
 | container\_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `512` | no |
 | container\_memory\_reservation | The amount of RAM (Soft Limit) to allow container to use in MB. This value must be less than `container_memory` if set | `number` | `128` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -76,6 +76,7 @@
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |
 | container\_cpu | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
+| container\_definition | Override the main container\_definition | `string` | `[]` | no |
 | container\_image | The default container image to use in container definition | `string` | `"cloudposse/default-backend"` | no |
 | container\_memory | The amount of RAM to allow container to use in MB. (If FARGATE launch type is used below, this must be a supported Memory size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `512` | no |
 | container\_memory\_reservation | The amount of RAM (Soft Limit) to allow container to use in MB. This value must be less than `container_memory` if set | `number` | `128` | no |

--- a/main.tf
+++ b/main.tf
@@ -118,6 +118,11 @@ locals {
       condition     = init_container.condition
     }
   ]
+
+  # override container_definition if var.container_definition is supplied
+  main_container_definition = coalesce(var.container_definition, module.container_definition.json_map)
+  # combine all container definitions
+  all_container_definitions = "[${join(",", concat(local.init_container_definitions, [local.main_container_definition]))}]"
 }
 
 module "ecs_alb_service_task" {
@@ -130,7 +135,7 @@ module "ecs_alb_service_task" {
   use_alb_security_group            = var.use_alb_security_group
   nlb_cidr_blocks                   = var.nlb_cidr_blocks
   use_nlb_cidr_blocks               = var.use_nlb_cidr_blocks
-  container_definition_json         = "[${join(",", concat(local.init_container_definitions, [module.container_definition.json_map]))}]"
+  container_definition_json         = local.all_container_definitions
   desired_count                     = var.desired_count
   health_check_grace_period_seconds = var.health_check_grace_period_seconds
   task_cpu                          = coalesce(var.task_cpu, var.container_cpu)

--- a/variables.tf
+++ b/variables.tf
@@ -881,5 +881,5 @@ variable "init_containers" {
 variable "container_definition" {
   type        = string
   description = "Override the main container_definition"
-  default     = []
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -877,3 +877,9 @@ variable "init_containers" {
   description = "A list of additional init containers to start. The map contains the container_definition (JSON) and the main container's dependency condition (string) on the init container. The latter can be one of START, COMPLETE, SUCCESS or HEALTHY."
   default     = []
 }
+
+variable "container_definition" {
+  type        = map(string)
+  description = "Override the main container_definition"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -879,7 +879,7 @@ variable "init_containers" {
 }
 
 variable "container_definition" {
-  type        = map(string)
+  type        = string
   description = "Override the main container_definition"
   default     = []
 }


### PR DESCRIPTION
## what
* My use case is that I want to pass in a list of container definitions. We can append the list of container definitions using var.init_containers but unfortunately cannot overrride the main container definition.

## why
* To support other log drivers and other container definition features without having to create more logic or expose additional input variables

## references
* Partially closes https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/57

