### PR TITLE
Cloudwatch log group enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ Available targets:
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
-| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `boolean` | `true` | no |
+| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ Available targets:
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
+| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `boolean` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -71,7 +71,7 @@
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
-| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `boolean` | `true` | no |
+| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -71,6 +71,7 @@
 | build\_timeout | How long in minutes, from 5 to 480 (8 hours), for AWS CodeBuild to wait until timing out any related build that does not get marked as completed | `number` | `60` | no |
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
+| cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `boolean` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,8 @@ module "ecr" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
+  count = var.cloudwatch_log_group_enabled ? 1 : 0
+
   name              = module.default_label.id
   tags              = module.default_label.tags
   retention_in_days = var.log_retention_in_days

--- a/main.tf
+++ b/main.tf
@@ -84,15 +84,15 @@ module "container_definition" {
   mount_points                 = var.mount_points
   container_depends_on         = local.container_depends_on
 
-  log_configuration = {
+  log_configuration = var.cloudwatch_log_group_enabled ? {
     logDriver = var.log_driver
     options = {
       "awslogs-region"        = var.aws_logs_region
-      "awslogs-group"         = aws_cloudwatch_log_group.app.name
+      "awslogs-group"         = join("", aws_cloudwatch_log_group.app.*.name)
       "awslogs-stream-prefix" = var.name
     }
     secretOptions = null
-  }
+  } : null
 }
 
 locals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -110,12 +110,12 @@ output "ecs_task_definition_revision" {
 
 output "cloudwatch_log_group_arn" {
   description = "Cloudwatch log group ARN"
-  value       = aws_cloudwatch_log_group.app.arn
+  value       = join("", aws_cloudwatch_log_group.app.*.arn)
 }
 
 output "cloudwatch_log_group_name" {
   description = "Cloudwatch log group name"
-  value       = aws_cloudwatch_log_group.app.name
+  value       = join("", aws_cloudwatch_log_group.app.*.name)
 }
 
 output "codebuild_project_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -877,3 +877,9 @@ variable "init_containers" {
   description = "A list of additional init containers to start. The map contains the container_definition (JSON) and the main container's dependency condition (string) on the init container. The latter can be one of START, COMPLETE, SUCCESS or HEALTHY."
   default     = []
 }
+
+variable "cloudwatch_log_group_enabled" {
+  type        = boolean
+  description = "A boolean to disable cloudwatch log group creation"
+  default     = false
+}

--- a/variables.tf
+++ b/variables.tf
@@ -879,7 +879,7 @@ variable "init_containers" {
 }
 
 variable "cloudwatch_log_group_enabled" {
-  type        = boolean
+  type        = bool
   description = "A boolean to disable cloudwatch log group creation"
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -881,5 +881,5 @@ variable "init_containers" {
 variable "cloudwatch_log_group_enabled" {
   type        = boolean
   description = "A boolean to disable cloudwatch log group creation"
-  default     = false
+  default     = true
 }


### PR DESCRIPTION
## what
* Disable cloudwatch log group if boolean set to false

## why
* If we don't want to log to cloudwatch if we're using a custom container definition, then we should be able to disable the log group

## references
* Partially closes https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/57

