### PR TITLE
Map environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Available targets:
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
 | log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
-| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}, environment override map\_environment | `map(string)` | `null` | no |
+| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}. `environment` overrides `map_environment` | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Available targets:
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
 | log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
+| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}, environment override map\_environment | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -125,6 +125,7 @@
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
 | log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
+| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}, environment override map\_environment | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -125,7 +125,7 @@
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
 | log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
-| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}, environment override map\_environment | `map(string)` | `null` | no |
+| map\_environment | The environment variables to pass to the container. This is a map of string: {key: value}. `environment` overrides `map_environment` | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -74,6 +74,7 @@ module "container_definition" {
   stop_timeout                 = var.container_stop_timeout
   healthcheck                  = var.healthcheck
   environment                  = var.environment
+  map_environment              = var.map_environment
   port_mappings                = var.port_mappings
   privileged                   = var.privileged
   secrets                      = var.secrets

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,12 @@ variable "environment" {
   default     = null
 }
 
+variable "map_environment" {
+  type        = map(string)
+  description = "The environment variables to pass to the container. This is a map of string: {key: value}, environment override map_environment"
+  default     = null
+}
+
 variable "entrypoint" {
   type        = list(string)
   description = "The entry point that is passed to the container"

--- a/variables.tf
+++ b/variables.tf
@@ -244,7 +244,7 @@ variable "environment" {
 
 variable "map_environment" {
   type        = map(string)
-  description = "The environment variables to pass to the container. This is a map of string: {key: value}, environment override map_environment"
+  description = "The environment variables to pass to the container. This is a map of string: {key: value}. `environment` overrides `map_environment`"
   default     = null
 }
 


### PR DESCRIPTION
## what
* Use the `map_environment` argument of the container definition module to make the environment variables more readable

## why
* More readable environment variables

## references
* Closes https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/56

