### PR TITLE
Add variables to override load balancer's container name

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ Available targets:
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | alb\_arn\_suffix | ARN suffix of the ALB for the Target Group | `string` | `""` | no |
+| alb\_container\_name | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |
 | alb\_ingress\_authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns\_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
@@ -256,6 +257,7 @@ Available targets:
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | nlb\_cidr\_blocks | A list of CIDR blocks to add to the ingress rule for the NLB container port | `list(string)` | `[]` | no |
+| nlb\_container\_name | The name of the container to associate with the NLB. If not provided, the generated container will be used | `string` | `null` | no |
 | nlb\_container\_port | The port number on the container bound to assigned NLB host\_port | `number` | `80` | no |
 | nlb\_ingress\_target\_group\_arn | Target group ARN of the NLB ingress | `string` | `""` | no |
 | platform\_version | The platform version on which to run your service. Only applicable for launch\_type set to FARGATE. More information about Fargate platform versions can be found in the AWS ECS User Guide. | `string` | `"LATEST"` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -19,6 +19,7 @@
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | alb\_arn\_suffix | ARN suffix of the ALB for the Target Group | `string` | `""` | no |
+| alb\_container\_name | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |
 | alb\_ingress\_authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns\_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
@@ -130,6 +131,7 @@
 | name | Name of the application | `string` | n/a | yes |
 | namespace | Namespace (e.g. `eg` or `cp`) | `string` | `""` | no |
 | nlb\_cidr\_blocks | A list of CIDR blocks to add to the ingress rule for the NLB container port | `list(string)` | `[]` | no |
+| nlb\_container\_name | The name of the container to associate with the NLB. If not provided, the generated container will be used | `string` | `null` | no |
 | nlb\_container\_port | The port number on the container bound to assigned NLB host\_port | `number` | `80` | no |
 | nlb\_ingress\_target\_group\_arn | Target group ARN of the NLB ingress | `string` | `""` | no |
 | platform\_version | The platform version on which to run your service. Only applicable for launch\_type set to FARGATE. More information about Fargate platform versions can be found in the AWS ECS User Guide. | `string` | `"LATEST"` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -24,7 +24,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -24,19 +24,21 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
-  availability_zones   = var.availability_zones
-  namespace            = var.namespace
-  stage                = var.stage
-  name                 = var.name
-  attributes           = var.attributes
-  delimiter            = var.delimiter
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
-  nat_instance_enabled = false
-  tags                 = var.tags
+  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
+  availability_zones       = var.availability_zones
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  attributes               = var.attributes
+  delimiter                = var.delimiter
+  vpc_id                   = module.vpc.vpc_id
+  igw_id                   = module.vpc.igw_id
+  cidr_block               = module.vpc.vpc_cidr_block
+  nat_gateway_enabled      = true
+  nat_instance_enabled     = false
+  aws_route_create_timeout = "5m"
+  aws_route_delete_timeout = "10m"
+  tags                     = var.tags
 }
 
 module "alb" {

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -18,17 +18,19 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
-  availability_zones   = local.availability_zones
-  namespace            = var.namespace
-  stage                = var.stage
-  name                 = var.name
-  region               = var.region
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
-  nat_instance_enabled = false
+  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
+  availability_zones       = local.availability_zones
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  region                   = var.region
+  vpc_id                   = module.vpc.vpc_id
+  igw_id                   = module.vpc.igw_id
+  cidr_block               = module.vpc.vpc_cidr_block
+  nat_gateway_enabled      = true
+  nat_instance_enabled     = false
+  aws_route_create_timeout = "5m"
+  aws_route_delete_timeout = "10m"
 }
 
 module "alb" {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -18,17 +18,19 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
-  availability_zones   = local.availability_zones
-  namespace            = var.namespace
-  stage                = var.stage
-  name                 = var.name
-  region               = var.region
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
-  nat_instance_enabled = false
+  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
+  availability_zones       = local.availability_zones
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  region                   = var.region
+  vpc_id                   = module.vpc.vpc_id
+  igw_id                   = module.vpc.igw_id
+  cidr_block               = module.vpc.vpc_cidr_block
+  nat_gateway_enabled      = true
+  nat_instance_enabled     = false
+  aws_route_create_timeout = "5m"
+  aws_route_delete_timeout = "10m"
 }
 
 module "alb" {

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -18,17 +18,19 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
-  availability_zones   = local.availability_zones
-  namespace            = var.namespace
-  stage                = var.stage
-  name                 = var.name
-  region               = var.region
-  vpc_id               = module.vpc.vpc_id
-  igw_id               = module.vpc.igw_id
-  cidr_block           = module.vpc.vpc_cidr_block
-  nat_gateway_enabled  = true
-  nat_instance_enabled = false
+  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.27.0"
+  availability_zones       = local.availability_zones
+  namespace                = var.namespace
+  stage                    = var.stage
+  name                     = var.name
+  region                   = var.region
+  vpc_id                   = module.vpc.vpc_id
+  igw_id                   = module.vpc.igw_id
+  cidr_block               = module.vpc.vpc_cidr_block
+  nat_gateway_enabled      = true
+  nat_instance_enabled     = false
+  aws_route_create_timeout = "5m"
+  aws_route_delete_timeout = "10m"
 }
 
 module "alb" {

--- a/main.tf
+++ b/main.tf
@@ -98,13 +98,13 @@ module "container_definition" {
 
 locals {
   alb = {
-    container_name   = module.default_label.id
+    container_name   = coalesce(var.alb_container_name, module.default_label.id)
     container_port   = var.container_port
     elb_name         = null
     target_group_arn = module.alb_ingress.target_group_arn
   }
   nlb = {
-    container_name   = module.default_label.id
+    container_name   = coalesce(var.nlb_container_name, module.default_label.id)
     container_port   = var.nlb_container_port
     elb_name         = null
     target_group_arn = var.nlb_ingress_target_group_arn

--- a/variables.tf
+++ b/variables.tf
@@ -895,3 +895,15 @@ variable "cloudwatch_log_group_enabled" {
   description = "A boolean to disable cloudwatch log group creation"
   default     = true
 }
+
+variable "alb_container_name" {
+  type        = string
+  description = "The name of the container to associate with the ALB. If not provided, the generated container will be used"
+  default     = null
+}
+
+variable "nlb_container_name" {
+  type        = string
+  description = "The name of the container to associate with the NLB. If not provided, the generated container will be used"
+  default     = null
+}


### PR DESCRIPTION
## What

Add `alb_container_name` and `nlb_container_name` variables, which are prioritized when building the ECS load balancers, instead of using the container name of the generated container definition.

## Why
An example use case for this implementation is adding a NGINX reverse proxy container acting as a sidecar. For that configuration:

* The main container definition is actually related to the downstream application (e.g. Django application exposing a Gunicorn server in port 5000).
* NGINX reverse proxy is configured within `init_containers`, exposing port 80. Now, we need load balancers to point to the NGINX container in port 80.
* Up until now, it wasn't possible to have this configuration, as load balancers would point to the Gunicorn server instead.