### PR TITLE
Upgrade modules and examples to support Terraform 0.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -355,6 +356,7 @@ Available targets:
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_arn | ALB Target Group response time average CloudWatch metric alarm ARN |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_id | ALB Target Group response time average CloudWatch metric alarm ID |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
@@ -229,3 +230,4 @@
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_arn | ALB Target Group response time average CloudWatch metric alarm ARN |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_id | ALB Target Group response time average CloudWatch metric alarm ID |
 
+<!-- markdownlint-restore -->

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -131,3 +131,5 @@ codepipeline_build_image = "aws/codebuild/docker:17.09.0"
 codepipeline_build_timeout = 20
 
 codepipeline_github_webhooks_anonymous = true
+
+environment = []

--- a/examples/complete/fixtures.us-east-2.tfvars
+++ b/examples/complete/fixtures.us-east-2.tfvars
@@ -129,3 +129,5 @@ codepipeline_badge_enabled = false
 codepipeline_build_image = "aws/codebuild/docker:17.09.0"
 
 codepipeline_build_timeout = 20
+
+codepipeline_github_webhooks_anonymous = true

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -13,7 +13,7 @@ module "label" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -24,7 +24,7 @@ module "vpc" {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
   availability_zones   = var.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -40,7 +40,7 @@ module "subnets" {
 }
 
 module "alb" {
-  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.11.0"
+  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.17.0"
   namespace                               = var.namespace
   stage                                   = var.stage
   name                                    = var.name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.18.0"
   namespace  = var.namespace
   name       = var.name
   stage      = var.stage
@@ -13,7 +13,7 @@ module "label" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -42,7 +42,7 @@ module "subnets" {
 }
 
 module "alb" {
-  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.11.0"
+  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.17.0"
   namespace                               = var.namespace
   stage                                   = var.stage
   name                                    = var.name

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -100,7 +100,7 @@ output "container_definition_json" {
 
 output "container_definition_json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = module.ecs_web_app.container_definition_json
+  value       = module.ecs_web_app.container_definition_json_map
 }
 
 output "ecs_exec_role_policy_id" {

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -100,7 +100,7 @@ output "container_definition_json" {
 
 output "container_definition_json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = module.ecs_web_app.container_definition_json_map
+  value       = module.ecs_web_app.container_definition_json
 }
 
 output "ecs_exec_role_policy_id" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
     aws      = "~> 2.0"

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -55,7 +55,7 @@ module "alb" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.18.0"
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -32,7 +32,7 @@ module "subnets" {
 }
 
 module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.11.0"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.17.0"
   name                      = var.name
   namespace                 = var.namespace
   stage                     = var.stage

--- a/examples/with_cognito_authentication/versions.tf
+++ b/examples/with_cognito_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
     aws      = "~> 2.0"

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -23,7 +23,6 @@ module "subnets" {
   namespace            = var.namespace
   stage                = var.stage
   name                 = var.name
-  region               = var.region
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
   cidr_block           = module.vpc.vpc_cidr_block
@@ -98,15 +97,8 @@ module "web_app" {
   container_port   = 80
   build_timeout    = 5
 
-  log_configuration = {
-    logDriver = "awslogs"
-    options = {
-      "awslogs-region"        = var.region
-      "awslogs-group"         = aws_cloudwatch_log_group.app.name
-      "awslogs-stream-prefix" = var.name
-    }
-    secretOptions = null
-  }
+  cloudwatch_log_group_enabled = true
+  log_driver                   = "awslogs"
 
   codepipeline_enabled = false
   webhook_enabled      = false

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -52,7 +52,7 @@ module "alb" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.18.0"
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -32,7 +32,7 @@ module "subnets" {
 }
 
 module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.11.0"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.17.0"
   name                      = var.name
   namespace                 = var.namespace
   stage                     = var.stage

--- a/examples/with_google_oidc_authentication/versions.tf
+++ b/examples/with_google_oidc_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
     aws      = "~> 2.0"

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -23,7 +23,6 @@ module "subnets" {
   namespace            = var.namespace
   stage                = var.stage
   name                 = var.name
-  region               = var.region
   vpc_id               = module.vpc.vpc_id
   igw_id               = module.vpc.igw_id
   cidr_block           = module.vpc.vpc_cidr_block
@@ -98,15 +97,8 @@ module "web_app" {
   container_port   = 80
   build_timeout    = 5
 
-  log_configuration = {
-    logDriver = "awslogs"
-    options = {
-      "awslogs-region"        = var.region
-      "awslogs-group"         = aws_cloudwatch_log_group.app.name
-      "awslogs-stream-prefix" = var.name
-    }
-    secretOptions = null
-  }
+  cloudwatch_log_group_enabled = true
+  log_driver                   = "awslogs"
 
   codepipeline_enabled = false
   webhook_enabled      = false

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.2"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -52,7 +52,7 @@ module "alb" {
 }
 
 module "label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.18.0"
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -3,7 +3,7 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.14.0"
+  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.16.1"
   namespace  = var.namespace
   stage      = var.stage
   name       = var.name
@@ -18,7 +18,7 @@ locals {
 }
 
 module "subnets" {
-  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.19.0"
+  source               = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.26.0"
   availability_zones   = local.availability_zones
   namespace            = var.namespace
   stage                = var.stage
@@ -32,7 +32,7 @@ module "subnets" {
 }
 
 module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.11.0"
+  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.17.0"
   name                      = var.name
   namespace                 = var.namespace
   stage                     = var.stage

--- a/examples/without_authentication/versions.tf
+++ b/examples/without_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
     aws      = "~> 2.0"

--- a/main.tf
+++ b/main.tf
@@ -123,7 +123,7 @@ locals {
   ]
 
   # override container_definition if var.container_definition is supplied
-  main_container_definition = coalesce(var.container_definition, module.container_definition.json_map)
+  main_container_definition = coalesce(var.container_definition, module.container_definition.json_map_encoded)
   # combine all container definitions
   all_container_definitions = "[${join(",", concat(local.init_container_definitions, [local.main_container_definition]))}]"
 }

--- a/main.tf
+++ b/main.tf
@@ -162,7 +162,7 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled               = var.codepipeline_enabled
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.14.1"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.16.0"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "default_label" {
 }
 
 module "ecr" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.26.0"
+  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.25.0"
   enabled             = var.codepipeline_enabled
   name                = var.name
   namespace           = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -9,7 +9,7 @@ module "default_label" {
 }
 
 module "ecr" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.18.0"
+  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.25.0"
   enabled             = var.codepipeline_enabled
   name                = var.name
   namespace           = var.namespace
@@ -27,7 +27,7 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "alb_ingress" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.12.0"
+  source                       = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.13.2"
   name                         = var.name
   namespace                    = var.namespace
   stage                        = var.stage
@@ -64,7 +64,7 @@ module "alb_ingress" {
 }
 
 module "container_definition" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.37.0"
+  source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.41.0"
   container_name               = module.default_label.id
   container_image              = var.use_ecr_image ? module.ecr.repository_url : var.container_image
   container_memory             = var.container_memory
@@ -129,7 +129,7 @@ locals {
 }
 
 module "ecs_alb_service_task" {
-  source                            = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=tags/0.35.0"
+  source                            = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=tags/0.39.0"
   name                              = var.name
   namespace                         = var.namespace
   stage                             = var.stage
@@ -162,7 +162,7 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled               = var.codepipeline_enabled
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.13.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.14.1"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage
@@ -207,7 +207,7 @@ module "ecs_codepipeline" {
 
 module "ecs_cloudwatch_autoscaling" {
   enabled               = var.autoscaling_enabled
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=tags/0.2.0"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=tags/0.4.1"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage
@@ -230,7 +230,7 @@ locals {
 }
 
 module "ecs_cloudwatch_sns_alarms" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms.git?ref=tags/0.5.0"
+  source  = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms.git?ref=tags/0.7.1"
   enabled = var.ecs_alarms_enabled
 
   name       = var.name
@@ -296,7 +296,7 @@ module "ecs_cloudwatch_sns_alarms" {
 }
 
 module "alb_target_group_cloudwatch_sns_alarms" {
-  source                         = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.8.0"
+  source                         = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.11.2"
   enabled                        = var.alb_target_group_alarms_enabled
   name                           = var.name
   namespace                      = var.namespace

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 module "default_label" {
-  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.17.0"
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.18.0"
   name       = var.name
   namespace  = var.namespace
   stage      = var.stage
@@ -9,7 +9,7 @@ module "default_label" {
 }
 
 module "ecr" {
-  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.25.0"
+  source              = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.26.0"
   enabled             = var.codepipeline_enabled
   name                = var.name
   namespace           = var.namespace

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,7 +55,7 @@ output "container_definition" {
 
 output "container_definition_json" {
   description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = module.container_definition.json_map_encoded
+  value       = module.container_definition.json_map_encoded_list
 }
 
 output "container_definition_json_map" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -55,12 +55,12 @@ output "container_definition" {
 
 output "container_definition_json" {
   description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = module.container_definition.json
+  value       = module.container_definition.json_map_encoded
 }
 
 output "container_definition_json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
-  value       = module.container_definition.json_map
+  value       = module.container_definition.json_map_encoded
 }
 
 output "ecs_alb_service_task" {


### PR DESCRIPTION
## what
* Update any version pinning
* Updated examples
* (locally verified) no `terraform init` errors using cli in main module & examples
* (locally verified) no `terraform validate` errors using cli in main module & examples

## why
* Support Terraform 0.13