### PR TITLE
Terraform 0.14 upgrade

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Use this file to define individuals or teams that are responsible for code in a repository.
 # Read more: <https://help.github.com/articles/about-codeowners/>
 #
-# Order is important: the last matching pattern takes the most precedence
+# Order is important: the last matching pattern has the highest precedence
 
 # These owners will be the default owners for everything
 *             @cloudposse/engineering @cloudposse/contributors
@@ -13,5 +13,12 @@
 # Cloud Posse must review any changes to GitHub actions
 .github/*     @cloudposse/engineering
 
-# Cloud Posse must review any changes to standard context definition
-**/context.tf   @cloudposse/engineering
+# Cloud Posse must review any changes to standard context definition,
+# but some changes can be rubber-stamped.
+**/context.tf   @cloudposse/engineering @cloudposse/approvers
+README.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+docs/*.md       @cloudposse/engineering @cloudposse/contributors @cloudposse/approvers
+
+# Cloud Posse Admins must review all changes to CODEOWNERS or the mergify configuration
+.github/mergify.yml @cloudposse/admins
+.github/CODEOWNERS  @cloudposse/admins

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -43,3 +43,11 @@ change-template: |
 
 template: |
   $CHANGES
+
+replacers:
+# Remove irrelevant information from Renovate bot
+- search: '/---\s+^#.*Renovate configuration(?:.|\n)*?This PR has been generated .*/gm'
+  replace: ''
+# Remove Renovate bot banner image
+- search: '/\[!\[[^\]]*Renovate\][^\]]*\](\([^)]*\))?\s*\n+/gm'
+  replace: ''

--- a/.github/auto-release.yml
+++ b/.github/auto-release.yml
@@ -1,33 +1,38 @@
-name-template: "v$RESOLVED_VERSION"
-tag-template: "$RESOLVED_VERSION"
-version-template: "$MAJOR.$MINOR.$PATCH"
+name-template: 'v$RESOLVED_VERSION'
+tag-template: '$RESOLVED_VERSION'
+version-template: '$MAJOR.$MINOR.$PATCH'
 version-resolver:
   major:
     labels:
-      - "major"
+    - 'major'
   minor:
     labels:
-      - "minor"
-      - "enhancement"
+    - 'minor'
+    - 'enhancement'
   patch:
     labels:
-      - "patch"
-      - "fix"
-      - "bugfix"
-      - "bug"
-      - "hotfix"
-  default: "minor"
+    - 'auto-update'
+    - 'patch'
+    - 'fix'
+    - 'bugfix'
+    - 'bug'
+    - 'hotfix'
+  default: 'minor'
 
 categories:
-  - title: "🚀 Enhancements"
-    labels:
-      - "enhancement"
-  - title: "🐛 Bug Fixes"
-    labels:
-      - "fix"
-      - "bugfix"
-      - "bug"
-      - "hotfix"
+- title: '🚀 Enhancements'
+  labels:
+  - 'enhancement'
+  - 'patch'
+- title: '🐛 Bug Fixes'
+  labels:
+  - 'fix'
+  - 'bugfix'
+  - 'bug'
+  - 'hotfix'
+- title: '🤖 Automatic Updates'
+  labels:
+  - 'auto-update'
 
 change-template: |
   <details>

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,12 +1,16 @@
+# https://docs.mergify.io/conditions.html
+# https://docs.mergify.io/actions.html
 pull_request_rules:
 - name: "approve automated PRs that have passed checks"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "author=cloudpossebot"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   actions:
     review:
       type: "APPROVE"
@@ -15,16 +19,17 @@ pull_request_rules:
 
 - name: "merge automated PRs when approved and tests pass"
   conditions:
-  - "check-success~=test/bats"
-  - "check-success~=test/readme"
-  - "check-success~=test/terratest"
+  - "author~=^(cloudpossebot|renovate\\[bot\\])$"
   - "base=master"
-  - "head~=auto-update/.*"
+  - "-closed"
+  - "head~=^(auto-update|renovate)/.*"
+  - "check-success=test/bats"
+  - "check-success=test/readme"
+  - "check-success=test/terratest"
+  - "check-success=validate-codeowners"
   - "#approved-reviews-by>=1"
   - "#changes-requested-reviews-by=0"
   - "#commented-reviews-by=0"
-  - "base=master"
-  - "author=cloudpossebot"
   actions:
     merge:
       method: "squash"
@@ -38,6 +43,7 @@ pull_request_rules:
 - name: "ask to resolve conflict"
   conditions:
   - "conflict"
+  - "-closed"
   actions:
     comment:
       message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"

--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -1,0 +1,52 @@
+pull_request_rules:
+- name: "approve automated PRs that have passed checks"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "author=cloudpossebot"
+  - "head~=auto-update/.*"
+  actions:
+    review:
+      type: "APPROVE"
+      bot_account: "cloudposse-mergebot"
+      message: "We've automatically approved this PR because the checks from the automated Pull Request have passed."
+
+- name: "merge automated PRs when approved and tests pass"
+  conditions:
+  - "check-success~=test/bats"
+  - "check-success~=test/readme"
+  - "check-success~=test/terratest"
+  - "base=master"
+  - "head~=auto-update/.*"
+  - "#approved-reviews-by>=1"
+  - "#changes-requested-reviews-by=0"
+  - "#commented-reviews-by=0"
+  - "base=master"
+  - "author=cloudpossebot"
+  actions:
+    merge:
+      method: "squash"
+
+- name: "delete the head branch after merge"
+  conditions:
+  - "merged"
+  actions:
+    delete_head_branch: {}
+
+- name: "ask to resolve conflict"
+  conditions:
+  - "conflict"
+  actions:
+    comment:
+      message: "This pull request is now in conflict. Could you fix it @{{author}}? 🙏"
+
+- name: "remove outdated reviews"
+  conditions:
+  - "base=master"
+  actions:
+    dismiss_reviews:
+      changes_requested: true
+      approved: true
+      message: "This Pull Request has been updated, so we're dismissing all reviews."

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    ":preserveSemverRanges"
+  ],
+  "labels": ["auto-update"],
+  "enabledManagers": ["terraform"],
+  "terraform": {
+    "ignorePaths": ["**/context.tf", "examples/**"]
+  }
+}
+

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -27,17 +27,19 @@ jobs:
             make init
             make github/init/context.tf
             make readme/build
-            echo "::set-output name=create_pull_request=true"
+            echo "::set-output name=create_pull_request::true"
           fi
         else
           echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
         fi
 
     - name: Create Pull Request
-      if: {{ steps.update.outputs.create_pull_request == 'true' }}
+      if: steps.update.outputs.create_pull_request == 'true'
       uses: cloudposse/actions/github/create-pull-request@0.22.0
       with:
         token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        committer: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
+        author: 'cloudpossebot <11232728+cloudpossebot@users.noreply.github.com>'
         commit-message: Update context.tf from origin source
         title: Update context.tf
         body: |-

--- a/.github/workflows/auto-context.yml
+++ b/.github/workflows/auto-context.yml
@@ -1,0 +1,55 @@
+name: "auto-context"
+on:
+  schedule:
+  # Update context.tf nightly
+  - cron:  '0 3 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update context.tf
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        if [[ -f context.tf ]]; then
+          echo "Discovered existing context.tf! Fetching most recent version to see if there is an update."
+          curl -o context.tf -fsSL https://raw.githubusercontent.com/cloudposse/terraform-null-label/master/exports/context.tf
+          if git diff --no-patch --exit-code context.tf; then
+            echo "No changes detected! Exiting the job..."
+          else
+            echo "context.tf file has changed. Update examples and rebuild README.md."
+            make init
+            make github/init/context.tf
+            make readme/build
+            echo "::set-output name=create_pull_request=true"
+          fi
+        else
+          echo "This module has not yet been updated to support the context.tf pattern! Please update in order to support automatic updates."
+        fi
+
+    - name: Create Pull Request
+      if: {{ steps.update.outputs.create_pull_request == 'true' }}
+      uses: cloudposse/actions/github/create-pull-request@0.22.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update context.tf from origin source
+        title: Update context.tf
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the `context.tf` file to the latest version from `cloudposse/terraform-null-label`
+
+          ## why
+          To support all the features of the `context` interface.
+
+        branch: auto-update/context.tf
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          context

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,0 +1,86 @@
+name: Auto Format
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+jobs:
+  auto-format:
+    runs-on: ubuntu-latest
+    container: cloudposse/build-harness:slim-latest
+    steps:
+    # Checkout the pull request branch
+    #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
+    #   the repository’s GITHUB_TOKEN, a new workflow will not run even when the repository contains
+    #   a workflow configured to run when push events occur."
+    # However, using a personal access token will cause events to be triggered.
+    # We need that to ensure a status gets posted after the auto-format commit.
+    # We also want to trigger tests if the auto-format made no changes.
+    - uses: actions/checkout@v2
+      if: github.event.pull_request.state == 'open'
+      name: Privileged Checkout
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        # Check out the PR commit, not the merge commit
+        # Use `ref` instead of `sha` to enable pushing back to `ref`
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    # Do all the formatting stuff
+    - name: Auto Format
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
+
+    # Commit changes (if any) to the PR branch
+    - name: Commit changes to the PR branch
+      if: github.event.pull_request.state == 'open'
+      shell: bash
+      id: commit
+      env:
+        SENDER: ${{ github.event.sender.login }}
+      run: |
+        set -x
+        output=$(git diff --name-only)
+
+        if [ -n "$output" ]; then
+          echo "Changes detected. Pushing to the PR branch"
+          git config --global user.name 'cloudpossebot'
+          git config --global user.email '11232728+cloudpossebot@users.noreply.github.com'
+          git add -A
+          git commit -m "Auto Format"
+          # Prevent looping by not pushing changes in response to changes from cloudpossebot
+          [[ $SENDER ==  "cloudpossebot" ]] || git push
+          # Set status to fail, because the push should trigger another status check,
+          # and we use success to indicate the checks are finished.
+          printf "::set-output name=%s::%s\n" "changed" "true"
+          exit 1
+        else
+          printf "::set-output name=%s::%s\n" "changed" "false"
+          echo "No changes detected"
+        fi
+
+    - name: Auto Test
+      uses: cloudposse/actions/github/repository-dispatch@0.22.0
+      # match users by ID because logins (user names) are inconsistent,
+      # for example in the REST API Renovate Bot is `renovate[bot]` but
+      # in GraphQL it is just `renovate`, plus there is a non-bot
+      # user `renovate` with ID 1832810.
+      # Mergify bot: 37929162
+      # Renovate bot: 29139614
+      # Cloudpossebot: 11232728
+      # Need to use space separators to prevent "21" from matching "112144"
+      if: >
+        contains(' 37929162 29139614 11232728 ', format(' {0} ', github.event.pull_request.user.id))
+        && steps.commit.outputs.changed == 'false' && github.event.pull_request.state == 'open'
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        repository: cloudposse/actions
+        event-type: test-command
+        client-payload: |-
+          { "slash_command":{"args": {"unnamed": {"all": "all", "arg1": "all"}}},
+             "pull_request": ${{ toJSON(github.event.pull_request) }},
+             "github":{"payload":{"repository": ${{ toJSON(github.event.repository) }},
+                                  "comment": {"id": ""}
+                                 }
+                      }
+          }

--- a/.github/workflows/auto-readme.yml
+++ b/.github/workflows/auto-readme.yml
@@ -1,0 +1,41 @@
+name: "auto-readme"
+on:
+  schedule:
+  # Update README.md nightly
+  - cron:  '0 4 * * *'
+
+jobs:
+  update:
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Update readme
+      shell: bash
+      id: update
+      env:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+      run: |
+        make init
+        make readme/build
+
+    - name: Create Pull Request
+      uses: cloudposse/actions/github/create-pull-request@0.20.0
+      with:
+        token: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+        commit-message: Update README.md and docs
+        title: Update README.md and docs
+        body: |-
+          ## what
+          This is an auto-generated PR that updates the README.md and docs
+
+          ## why
+          To have most recent changes of README.md and doc from origin templates
+
+        branch: auto-update/readme
+        base: master
+        delete-branch: true
+        labels: |
+          auto-update
+          readme

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -6,7 +6,7 @@ on:
     - master
 
 jobs:
-  semver:
+  publish:
     runs-on: ubuntu-latest
     steps:
     # Drafts your next Release notes as Pull Requests are merged into "master"

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,17 +3,17 @@ name: auto-release
 on:
   push:
     branches:
-      - master
+    - master
 
 jobs:
   semver:
     runs-on: ubuntu-latest
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          publish: true
-          prerelease: false
-          config-name: auto-release.yml
-        env:
-          GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}
+    # Drafts your next Release notes as Pull Requests are merged into "master"
+    - uses: release-drafter/release-drafter@v5
+      with:
+        publish: true
+        prerelease: false
+        config-name: auto-release.yml
+      env:
+        GITHUB_TOKEN: ${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}

--- a/.github/workflows/chatops.yml
+++ b/.github/workflows/chatops.yml
@@ -33,3 +33,5 @@ jobs:
           permission: triage
           issue-type: pull-request
           reactions: false
+
+

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -9,6 +9,8 @@ jobs:
     - name: "Checkout source code at current commit"
       uses: actions/checkout@v2
     - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name == github.repository
+      name: "Full check of CODEOWNERS"
       with:
         # For now, remove "files" check to allow CODEOWNERS to specify non-existent
         # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
@@ -16,3 +18,8 @@ jobs:
         checks: "syntax,owners,duppatterns"
         # GitHub access token is required only if the `owners` check is enabled
         github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
+    - uses: mszostok/codeowners-validator@v0.5.0
+      if: github.event.pull_request.head.repo.full_name != github.repository
+      name: "Syntax check of CODEOWNERS"
+      with:
+        checks: "syntax,duppatterns"

--- a/.github/workflows/validate-codeowners.yml
+++ b/.github/workflows/validate-codeowners.yml
@@ -1,0 +1,18 @@
+name: Validate Codeowners
+on:
+  pull_request:
+
+jobs:
+  validate-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Checkout source code at current commit"
+      uses: actions/checkout@v2
+    - uses: mszostok/codeowners-validator@v0.5.0
+      with:
+        # For now, remove "files" check to allow CODEOWNERS to specify non-existent
+        # files so we can use the same CODEOWNERS file for Terraform and non-Terraform repos
+        #   checks: "files,syntax,owners,duppatterns"
+        checks: "syntax,owners,duppatterns"
+        # GitHub access token is required only if the `owners` check is enabled
+        github_access_token: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,15 @@ We literally have [*hundreds of terraform modules*][terraform_modules] that are 
 ## Usage
 
 
-**IMPORTANT:** The `master` branch is used in `source` just as an example. In your code, do not pin to `master` because there may be breaking changes between releases.
-Instead pin to the release tag (e.g. `?ref=tags/x.y.z`) of one of our [latest releases](https://github.com/cloudposse/terraform-aws-ecs-web-app/releases).
+**IMPORTANT:** We do not pin modules to versions in our examples because of the
+difficulty of keeping the versions in the documentation in sync with the latest released versions.
+We highly recommend that in your code you pin the version to the exact version you are
+using so that your infrastructure remains stable, and update versions in a
+systematic way so that they do not catch you by surprise.
+
+Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
+the registry shows many of our inputs as required when in fact they are optional.
+The table below correctly indicates which inputs are required.
 
 
 For a complete example, see [examples/complete](examples/complete).
@@ -80,7 +87,9 @@ Other examples:
 
 ```
 module "default_backend_web_app" {
-  source                                          = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
+  source = "cloudposse/ecs-web-app/aws"
+  # Cloud Posse recommends pinning every module to a specific version
+  # version     = "x.x.x"
   namespace                                       = "eg"
   stage                                           = "testing"
   name                                            = "appname"
@@ -131,7 +140,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |
@@ -469,7 +478,7 @@ In general, PRs are welcome. We follow the typical "fork-and-pull" Git workflow.
 
 ## Copyright
 
-Copyright © 2017-2020 [Cloud Posse, LLC](https://cpco.io/copyright)
+Copyright © 2017-2021 [Cloud Posse, LLC](https://cpco.io/copyright)
 
 
 

--- a/README.yaml
+++ b/README.yaml
@@ -82,7 +82,9 @@ usage: |-
 
   ```
   module "default_backend_web_app" {
-    source                                          = "git::https://github.com/cloudposse/terraform-aws-ecs-web-app.git?ref=master"
+    source = "cloudposse/ecs-web-app/aws"
+    # Cloud Posse recommends pinning every module to a specific version
+    # version     = "x.x.x"
     namespace                                       = "eg"
     stage                                           = "testing"
     name                                            = "appname"

--- a/context.tf
+++ b/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
+  source  = "cloudposse/label/null"
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -3,7 +3,7 @@
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0 |
+| terraform | >= 0.12.26 |
 | aws | >= 2.0 |
 | local | >= 1.3 |
 | null | >= 2.0 |

--- a/examples/complete/context.tf
+++ b/examples/complete/context.tf
@@ -19,7 +19,8 @@
 #
 
 module "this" {
-  source = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.21.0"
+  source  = "cloudposse/label/null"
+  version = "0.22.1" // requires Terraform >= 0.12.26
 
   enabled             = var.enabled
   namespace           = var.namespace

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 module "vpc" {
   source     = "cloudposse/vpc/aws"
-  version    = "0.18.0"
+  version    = "0.18.2"
   cidr_block = var.vpc_cidr_block
 
   context = module.this.context
@@ -13,7 +13,7 @@ module "vpc" {
 
 module "subnets" {
   source                   = "cloudposse/dynamic-subnets/aws"
-  version                  = "0.32.0"
+  version                  = "0.34.0"
   availability_zones       = var.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -28,7 +28,7 @@ module "subnets" {
 
 module "alb" {
   source                                  = "cloudposse/alb/aws"
-  version                                 = "0.23.0"
+  version                                 = "0.27.0"
   vpc_id                                  = module.vpc.vpc_id
   security_group_ids                      = [module.vpc.vpc_default_security_group_id]
   subnet_ids                              = module.subnets.public_subnet_ids

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0"
+  source     = "cloudposse/vpc/aws"
+  version    = "0.18.0"
   cidr_block = var.vpc_cidr_block
 
   context = module.this.context
@@ -11,7 +12,8 @@ module "vpc" {
 }
 
 module "subnets" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.32.0"
+  source                   = "cloudposse/dynamic-subnets/aws"
+  version                  = "0.32.0"
   availability_zones       = var.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -25,7 +27,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.23.0"
+  source                                  = "cloudposse/alb/aws"
+  version                                 = "0.23.0"
   vpc_id                                  = module.vpc.vpc_id
   security_group_ids                      = [module.vpc.vpc_default_security_group_id]
   subnet_ids                              = module.subnets.public_subnet_ids

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    null     = ">= 2.0"
-    local    = ">= 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
   }
 }

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "cloudposse/vpc/aws"
-  version     = "0.18.0"
+  source  = "cloudposse/vpc/aws"
+  version = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -19,8 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source = "cloudposse/dynamic-subnets/aws"
-  version     = "0.32.0"
+  source                   = "cloudposse/dynamic-subnets/aws"
+  version                  = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -34,8 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source = "cloudposse/alb/aws"
-  version     = "0.23.0"
+  source                                  = "cloudposse/alb/aws"
+  version                                 = "0.23.0"
   vpc_id                                  = module.vpc.vpc_id
   security_group_ids                      = [module.vpc.vpc_default_security_group_id]
   subnet_ids                              = module.subnets.public_subnet_ids

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0"
+  source = "cloudposse/vpc/aws"
+  version     = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -18,7 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.32.0"
+  source = "cloudposse/dynamic-subnets/aws"
+  version     = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -32,7 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source                                  = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.23.0"
+  source = "cloudposse/alb/aws"
+  version     = "0.23.0"
   vpc_id                                  = module.vpc.vpc_id
   security_group_ids                      = [module.vpc.vpc_default_security_group_id]
   subnet_ids                              = module.subnets.public_subnet_ids

--- a/examples/with_cognito_authentication/versions.tf
+++ b/examples/with_cognito_authentication/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    null     = ">= 2.0"
-    local    = ">= 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
   }
 }

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "cloudposse/vpc/aws"
-  version     = "0.18.0"
+  source  = "cloudposse/vpc/aws"
+  version = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -19,8 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source = "cloudposse/dynamic-subnets/aws"
-  version     = "0.32.0"
+  source                   = "cloudposse/dynamic-subnets/aws"
+  version                  = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -34,8 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source = "cloudposse/alb/aws"
-  version     = "0.23.0"
+  source                    = "cloudposse/alb/aws"
+  version                   = "0.23.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0"
+  source = "cloudposse/vpc/aws"
+  version     = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -18,7 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.32.0"
+  source = "cloudposse/dynamic-subnets/aws"
+  version     = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -32,7 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.23.0"
+  source = "cloudposse/alb/aws"
+  version     = "0.23.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/with_google_oidc_authentication/versions.tf
+++ b/examples/with_google_oidc_authentication/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    null     = ">= 2.0"
-    local    = ">= 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
   }
 }

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -3,8 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "cloudposse/vpc/aws"
-  version     = "0.18.0"
+  source  = "cloudposse/vpc/aws"
+  version = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -19,8 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source = "cloudposse/dynamic-subnets/aws"
-  version     = "0.32.0"
+  source                   = "cloudposse/dynamic-subnets/aws"
+  version                  = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -34,8 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source = "cloudposse/alb/aws"
-  version     = "0.23.0"
+  source                    = "cloudposse/alb/aws"
+  version                   = "0.23.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -3,7 +3,8 @@ provider "aws" {
 }
 
 module "vpc" {
-  source = "git::https://github.com/cloudposse/terraform-aws-vpc.git?ref=tags/0.18.0"
+  source = "cloudposse/vpc/aws"
+  version     = "0.18.0"
 
   cidr_block = "172.16.0.0/16"
 
@@ -18,7 +19,8 @@ locals {
 }
 
 module "subnets" {
-  source                   = "git::https://github.com/cloudposse/terraform-aws-dynamic-subnets.git?ref=tags/0.32.0"
+  source = "cloudposse/dynamic-subnets/aws"
+  version     = "0.32.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
   igw_id                   = module.vpc.igw_id
@@ -32,7 +34,8 @@ module "subnets" {
 }
 
 module "alb" {
-  source                    = "git::https://github.com/cloudposse/terraform-aws-alb.git?ref=tags/0.23.0"
+  source = "cloudposse/alb/aws"
+  version     = "0.23.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/without_authentication/versions.tf
+++ b/examples/without_authentication/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    null     = ">= 2.0"
-    local    = ">= 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 module "ecr" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ecr.git?ref=tags/0.29.1"
+  source  = "cloudposse/ecr/aws"
+  version = "0.29.1"
   enabled = var.codepipeline_enabled
 
   attributes          = ["ecr"]
@@ -17,7 +18,8 @@ resource "aws_cloudwatch_log_group" "app" {
 }
 
 module "alb_ingress" {
-  source = "git::https://github.com/cloudposse/terraform-aws-alb-ingress.git?ref=tags/0.15.0"
+  source  = "cloudposse/alb-ingress/aws"
+  version = "0.15.0"
 
   vpc_id                       = var.vpc_id
   port                         = var.container_port
@@ -56,7 +58,8 @@ module "alb_ingress" {
 }
 
 module "container_definition" {
-  source                       = "git::https://github.com/cloudposse/terraform-aws-ecs-container-definition.git?ref=tags/0.45.2"
+  source                       = "cloudposse/ecs-container-definition/aws"
+  version                      = "0.45.2"
   container_name               = module.this.id
   container_image              = var.use_ecr_image ? module.ecr.repository_url : var.container_image
   container_memory             = var.container_memory
@@ -121,7 +124,8 @@ locals {
 }
 
 module "ecs_alb_service_task" {
-  source = "git::https://github.com/cloudposse/terraform-aws-ecs-alb-service-task.git?ref=tags/0.42.0"
+  source  = "cloudposse/ecs-alb-service-task/aws"
+  version = "0.42.0"
 
   alb_security_group                = var.alb_security_group
   use_alb_security_group            = var.use_alb_security_group
@@ -153,7 +157,8 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled = var.codepipeline_enabled
-  source  = "git::https://github.com/cloudposse/terraform-aws-ecs-codepipeline.git?ref=tags/0.18.0"
+  source  = "cloudposse/ecs-codepipeline/aws"
+  version = "0.18.0"
 
   region                = var.region
   github_oauth_token    = var.github_oauth_token
@@ -197,7 +202,8 @@ module "ecs_codepipeline" {
 
 module "ecs_cloudwatch_autoscaling" {
   enabled               = var.autoscaling_enabled
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=tags/0.4.2"
+  source                = "cloudposse/ecs-cloudwatch-autoscaling/aws"
+  version               = "0.4.2"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage
@@ -220,7 +226,8 @@ locals {
 }
 
 module "ecs_cloudwatch_sns_alarms" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-sns-alarms.git?ref=tags/0.8.1"
+  source  = "cloudposse/ecs-cloudwatch-sns-alarms/aws"
+  version = "0.8.1"
   enabled = var.ecs_alarms_enabled
 
   cluster_name = var.ecs_cluster_name
@@ -282,7 +289,8 @@ module "ecs_cloudwatch_sns_alarms" {
 }
 
 module "alb_target_group_cloudwatch_sns_alarms" {
-  source  = "git::https://github.com/cloudposse/terraform-aws-alb-target-group-cloudwatch-sns-alarms.git?ref=tags/0.12.1"
+  source  = "cloudposse/alb-target-group-cloudwatch-sns-alarms/aws"
+  version = "0.12.1"
   enabled = var.alb_target_group_alarms_enabled
 
   alarm_actions                  = var.alb_target_group_alarms_alarm_actions

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,6 @@
 module "ecr" {
   source  = "cloudposse/ecr/aws"
-  version = "0.29.1"
+  version = "0.29.2"
   enabled = var.codepipeline_enabled
 
   attributes          = ["ecr"]
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_log_group" "app" {
 
 module "alb_ingress" {
   source  = "cloudposse/alb-ingress/aws"
-  version = "0.15.0"
+  version = "0.16.1"
 
   vpc_id                       = var.vpc_id
   port                         = var.container_port
@@ -59,7 +59,7 @@ module "alb_ingress" {
 
 module "container_definition" {
   source                       = "cloudposse/ecs-container-definition/aws"
-  version                      = "0.45.2"
+  version                      = "0.46.2"
   container_name               = module.this.id
   container_image              = var.use_ecr_image ? module.ecr.repository_url : var.container_image
   container_memory             = var.container_memory
@@ -125,7 +125,7 @@ locals {
 
 module "ecs_alb_service_task" {
   source  = "cloudposse/ecs-alb-service-task/aws"
-  version = "0.42.0"
+  version = "0.44.0"
 
   alb_security_group                = var.alb_security_group
   use_alb_security_group            = var.use_alb_security_group
@@ -158,7 +158,7 @@ module "ecs_alb_service_task" {
 module "ecs_codepipeline" {
   enabled = var.codepipeline_enabled
   source  = "cloudposse/ecs-codepipeline/aws"
-  version = "0.18.0"
+  version = "0.19.0"
 
   region                = var.region
   github_oauth_token    = var.github_oauth_token
@@ -203,7 +203,7 @@ module "ecs_codepipeline" {
 module "ecs_cloudwatch_autoscaling" {
   enabled               = var.autoscaling_enabled
   source                = "cloudposse/ecs-cloudwatch-autoscaling/aws"
-  version               = "0.4.2"
+  version               = "0.5.1"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage
@@ -290,7 +290,7 @@ module "ecs_cloudwatch_sns_alarms" {
 
 module "alb_target_group_cloudwatch_sns_alarms" {
   source  = "cloudposse/alb-target-group-cloudwatch-sns-alarms/aws"
-  version = "0.12.1"
+  version = "0.13.0"
   enabled = var.alb_target_group_alarms_enabled
 
   alarm_actions                  = var.alb_target_group_alarms_alarm_actions

--- a/test/src/examples_complete_test.go
+++ b/test/src/examples_complete_test.go
@@ -100,25 +100,25 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	codebuildCacheBucketName := terraform.Output(t, terraformOptions, "codebuild_cache_bucket_name")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildCacheBucketName := "eg-test-ecs-web-app-" + attributes[0] + "-build"
+	expectedCodebuildCacheBucketName := "eg-test-ecs-web-app-build-" + attributes[0]
 	assert.Contains(t, codebuildCacheBucketName, expectedCodebuildCacheBucketName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildProjectName := terraform.Output(t, terraformOptions, "codebuild_project_name")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildProjectName := "eg-test-ecs-web-app-" + attributes[0] + "-build"
+	expectedCodebuildProjectName := "eg-test-ecs-web-app-build-" + attributes[0]
 	assert.Equal(t, expectedCodebuildProjectName, codebuildProjectName)
 
 	// Run `terraform output` to get the value of an output variable
 	codebuildRoleId := terraform.Output(t, terraformOptions, "codebuild_role_id")
 	// Verify we're getting back the outputs we expect
-	expectedCodebuildRoleId := "eg-test-ecs-web-app-" + attributes[0] + "-build"
+	expectedCodebuildRoleId := "eg-test-ecs-web-app-build-" + attributes[0]
 	assert.Equal(t, expectedCodebuildRoleId, codebuildRoleId)
 
 	// Run `terraform output` to get the value of an output variable
 	codepipelineId := terraform.Output(t, terraformOptions, "codepipeline_id")
 	// Verify we're getting back the outputs we expect
-	expectedCodepipelineId := "eg-test-ecs-web-app-codepipeline-" + attributes[0]
+	expectedCodepipelineId := "eg-test-ecs-web-app-" + attributes[0] + "-codepipeline"
 	assert.Equal(t, expectedCodepipelineId, codepipelineId)
 
 	// Run `terraform output` to get the value of an output variable
@@ -130,13 +130,13 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	ecsTaskRoleName := terraform.Output(t, terraformOptions, "ecs_task_role_name")
 	// Verify we're getting back the outputs we expect
-	expectedEcsTaskRoleName := "eg-test-ecs-web-app-task-" + attributes[0]
+	expectedEcsTaskRoleName := "eg-test-ecs-web-app-" + attributes[0] + "-task"
 	assert.Equal(t, expectedEcsTaskRoleName, ecsTaskRoleName)
 
 	// Run `terraform output` to get the value of an output variable
 	ecsTaskExecRoleName := terraform.Output(t, terraformOptions, "ecs_task_exec_role_name")
 	// Verify we're getting back the outputs we expect
-	expectedEcsTaskExecRoleName := "eg-test-ecs-web-app-exec-" + attributes[0]
+	expectedEcsTaskExecRoleName := "eg-test-ecs-web-app-" + attributes[0] + "-exec"
 	assert.Equal(t, expectedEcsTaskExecRoleName, ecsTaskExecRoleName)
 
 	// Run `terraform output` to get the value of an output variable
@@ -148,7 +148,7 @@ func TestExamplesComplete(t *testing.T) {
 	// Run `terraform output` to get the value of an output variable
 	ecsExecRolePolicyName := terraform.Output(t, terraformOptions, "ecs_exec_role_policy_name")
 	// Verify we're getting back the outputs we expect
-	expectedEcsExecRolePolicyName := "eg-test-ecs-web-app-exec-" + attributes[0]
+	expectedEcsExecRolePolicyName := "eg-test-ecs-web-app-" + attributes[0] + "-exec"
 	assert.Equal(t, expectedEcsExecRolePolicyName, ecsExecRolePolicyName)
 
 	// Run `terraform output` to get the value of an output variable

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,22 @@
 terraform {
-  required_version = ">= 0.12.0"
+  required_version = ">= 0.12.26"
 
   required_providers {
-    aws      = ">= 2.0"
-    template = ">= 2.0"
-    null     = ">= 2.0"
-    local    = ">= 1.3"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
   }
 }


### PR DESCRIPTION
## what
- Upgrade to support Terraform 0.14 and bring up to current Cloud Posse standard

## why
- Support Terraform 0.14
- supersedes and closes #83 

blocked by https://github.com/cloudposse/terraform-aws-ecs-codepipeline/pull/54/files