### PR TITLE
Increase the ecs cloudwatch autoscaling source module version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -197,7 +197,7 @@ module "ecs_codepipeline" {
 
 module "ecs_cloudwatch_autoscaling" {
   enabled               = var.autoscaling_enabled
-  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=tags/0.4.2"
+  source                = "git::https://github.com/cloudposse/terraform-aws-ecs-cloudwatch-autoscaling.git?ref=tags/0.5.0"
   name                  = var.name
   namespace             = var.namespace
   stage                 = var.stage


### PR DESCRIPTION
## what
* Increase the ecs cloudwatch autoscaling source module version from v0.4.2 to v0.5.0
* Increasing this version allows us to utilize terraform v14

## why
* Need to increase this version in order to utilize terraform v14 with this module

## references
* Linked to this issue: https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/82
