### PR TITLE
readme updated, BC checks fixed for example/test module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.tfstate
 *.tfstate.backup
 .terraform.tfstate.lock.info
+**/.terraform.lock.hcl
 
 # Module directory
 .terraform/

--- a/README.md
+++ b/README.md
@@ -142,9 +142,6 @@ Available targets:
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
-| template | >= 2.0 |
 
 ## Providers
 
@@ -274,7 +271,7 @@ Available targets:
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
-| log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
+| log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `90` | no |
 | map\_container\_environment | The environment variables to pass to the container. This is a map of string: {key: value}. `environment` overrides `map_environment` | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -5,9 +5,6 @@
 |------|---------|
 | terraform | >= 0.12.26 |
 | aws | >= 2.0 |
-| local | >= 1.3 |
-| null | >= 2.0 |
-| template | >= 2.0 |
 
 ## Providers
 
@@ -137,7 +134,7 @@
 | label\_order | The naming order of the id output and Name tag.<br>Defaults to ["namespace", "environment", "stage", "name", "attributes"].<br>You can omit any of the 5 elements, but at least one must be present. | `list(string)` | `null` | no |
 | launch\_type | The ECS launch type (valid options: FARGATE or EC2) | `string` | `"FARGATE"` | no |
 | log\_driver | The log driver to use for the container. If using Fargate launch type, only supported value is awslogs | `string` | `"awslogs"` | no |
-| log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `null` | no |
+| log\_retention\_in\_days | The number of days to retain logs for the log group | `number` | `90` | no |
 | map\_container\_environment | The environment variables to pass to the container. This is a map of string: {key: value}. `environment` overrides `map_environment` | `map(string)` | `null` | no |
 | mount\_points | Container mount points. This is a list of maps, where each map should contain a `containerPath` and `sourceVolume` | <pre>list(object({<br>    containerPath = string<br>    sourceVolume  = string<br>  }))</pre> | `[]` | no |
 | name | Solution name, e.g. 'app' or 'jenkins' | `string` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -46,12 +46,17 @@ module "alb" {
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
   tags = module.this.tags
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_sns_topic" "sns_topic" {
-  name         = module.this.id
-  display_name = "Test terraform-aws-ecs-web-app"
-  tags         = module.this.tags
+  name              = module.this.id
+  display_name      = "Test terraform-aws-ecs-web-app"
+  tags              = module.this.tags
+  kms_master_key_id = "alias/aws/sns"
 }
 
 module "ecs_web_app" {

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -53,11 +53,16 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  name = module.this.id
-  tags = module.this.tags
+  name              = module.this.id
+  tags              = module.this.tags
+  retention_in_days = 90
 }
 
 module "web_app" {

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -53,6 +53,7 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  tags = module.this.tags
   setting {
     name  = "containerInsights"
     value = "enabled"
@@ -60,6 +61,7 @@ resource "aws_ecs_cluster" "default" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
+  #bridgecrew:skip=BC_AWS_LOGGING_21:Skipping `Ensure CloudWatch logs are encrypted at rest using KMS CMKs` in example/test modules
   name              = module.this.id
   tags              = module.this.tags
   retention_in_days = 90

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -52,11 +52,16 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  name = module.this.id
-  tags = module.this.tags
+  name              = module.this.id
+  tags              = module.this.tags
+  retention_in_days = 90
 }
 
 module "web_app" {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -52,6 +52,7 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  tags = module.this.tags
   setting {
     name  = "containerInsights"
     value = "enabled"
@@ -59,6 +60,7 @@ resource "aws_ecs_cluster" "default" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
+  #bridgecrew:skip=BC_AWS_LOGGING_21:Skipping `Ensure CloudWatch logs are encrypted at rest using KMS CMKs` in example/test modules
   name              = module.this.id
   tags              = module.this.tags
   retention_in_days = 90

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -52,11 +52,16 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  setting {
+    name  = "containerInsights"
+    value = "enabled"
+  }
 }
 
 resource "aws_cloudwatch_log_group" "app" {
-  name = module.this.id
-  tags = module.this.tags
+  name              = module.this.id
+  tags              = module.this.tags
+  retention_in_days = 90
 }
 
 module "web_app" {

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -52,6 +52,7 @@ module "alb" {
 # ECS Cluster (needed even if using FARGATE launch type)
 resource "aws_ecs_cluster" "default" {
   name = module.this.id
+  tags = module.this.tags
   setting {
     name  = "containerInsights"
     value = "enabled"
@@ -59,6 +60,7 @@ resource "aws_ecs_cluster" "default" {
 }
 
 resource "aws_cloudwatch_log_group" "app" {
+  #bridgecrew:skip=BC_AWS_LOGGING_21:Skipping `Ensure CloudWatch logs are encrypted at rest using KMS CMKs` in example/test modules
   name              = module.this.id
   tags              = module.this.tags
   retention_in_days = 90

--- a/variables.tf
+++ b/variables.tf
@@ -433,7 +433,7 @@ variable "aws_logs_prefix" {
 variable "log_retention_in_days" {
   type        = number
   description = "The number of days to retain logs for the log group"
-  default     = null
+  default     = 90
 }
 
 variable "log_driver" {

--- a/versions.tf
+++ b/versions.tf
@@ -6,17 +6,5 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 2.0"
     }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0"
-    }
-    null = {
-      source  = "hashicorp/null"
-      version = ">= 2.0"
-    }
-    local = {
-      source  = "hashicorp/local"
-      version = ">= 1.3"
-    }
   }
 }


### PR DESCRIPTION
## what
* BridgeCrew compliance checks fix
* readme updated
* code clean up
* Skipping `Encrypt SNS Topic Data` in example/test modules
* `Container Insights Enabled` in example/test modules

## why
* To be able to position our modules as standards compliant
* Providing explicit note about policy attached directly to user
* removed unnecessary providers dependencies
* To comply BridgeCrew check

## references
* https://docs.bridgecrew.io/docs/general_15
* https://docs.bridgecrew.io/docs/logging_13
* https://docs.bridgecrew.io/docs/bc_aws_logging_11