### PR TITLE
Expose codepipeline build cache bucket suffix variable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,26 @@ Available targets:
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| alb_ingress | cloudposse/alb-ingress/aws | 0.20.0 |
+| alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
+| container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
+| ecr | cloudposse/ecr/aws | 0.32.2 |
+| ecs_alb_service_task | cloudposse/ecs-alb-service-task/aws | 0.47.0 |
+| ecs_cloudwatch_autoscaling | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.0 |
+| ecs_cloudwatch_sns_alarms | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.1 |
+| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.23.0 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -232,6 +252,7 @@ Available targets:
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
 | cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
+| codepipeline\_build\_cache\_bucket\_suffix\_enabled | The codebuild cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
@@ -396,7 +417,6 @@ Available targets:
 | httpcode\_target\_5xx\_count\_cloudwatch\_metric\_alarm\_id | ALB Target Group 5xx count CloudWatch metric alarm ID |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_arn | ALB Target Group response time average CloudWatch metric alarm ARN |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_id | ALB Target Group response time average CloudWatch metric alarm ID |
-
 <!-- markdownlint-restore -->
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -12,6 +12,26 @@
 |------|---------|
 | aws | >= 2.0 |
 
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| alb_ingress | cloudposse/alb-ingress/aws | 0.20.0 |
+| alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
+| container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
+| ecr | cloudposse/ecr/aws | 0.32.2 |
+| ecs_alb_service_task | cloudposse/ecs-alb-service-task/aws | 0.47.0 |
+| ecs_cloudwatch_autoscaling | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.0 |
+| ecs_cloudwatch_sns_alarms | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.1 |
+| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.23.0 |
+| this | cloudposse/label/null | 0.24.1 |
+
+## Resources
+
+| Name |
+|------|
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+
 ## Inputs
 
 | Name | Description | Type | Default | Required |
@@ -76,6 +96,7 @@
 | buildspec | Declaration to use for building the project. [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `""` | no |
 | capacity\_provider\_strategies | The capacity provider strategies to use for the service. See `capacity_provider_strategy` configuration block: https://www.terraform.io/docs/providers/aws/r/ecs_service.html#capacity_provider_strategy | <pre>list(object({<br>    capacity_provider = string<br>    weight            = number<br>    base              = number<br>  }))</pre> | `[]` | no |
 | cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
+| codepipeline\_build\_cache\_bucket\_suffix\_enabled | The codebuild cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
@@ -240,5 +261,4 @@
 | httpcode\_target\_5xx\_count\_cloudwatch\_metric\_alarm\_id | ALB Target Group 5xx count CloudWatch metric alarm ID |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_arn | ALB Target Group response time average CloudWatch metric alarm ARN |
 | target\_response\_time\_average\_cloudwatch\_metric\_alarm\_id | ALB Target Group response time average CloudWatch metric alarm ID |
-
 <!-- markdownlint-restore -->

--- a/main.tf
+++ b/main.tf
@@ -159,25 +159,26 @@ module "ecs_alb_service_task" {
 module "ecs_codepipeline" {
   enabled = var.codepipeline_enabled
   source  = "cloudposse/ecs-codepipeline/aws"
-  version = "0.22.0"
+  version = "0.23.0"
 
-  region                = var.region
-  github_oauth_token    = var.github_oauth_token
-  github_webhooks_token = var.github_webhooks_token
-  github_webhook_events = var.github_webhook_events
-  repo_owner            = var.repo_owner
-  repo_name             = var.repo_name
-  branch                = var.branch
-  badge_enabled         = var.badge_enabled
-  build_image           = var.build_image
-  build_compute_type    = var.codepipeline_build_compute_type
-  build_timeout         = var.build_timeout
-  buildspec             = var.buildspec
-  image_repo_name       = module.ecr.repository_name
-  service_name          = module.ecs_alb_service_task.service_name
-  ecs_cluster_name      = var.ecs_cluster_name
-  privileged_mode       = true
-  poll_source_changes   = var.poll_source_changes
+  region                      = var.region
+  github_oauth_token          = var.github_oauth_token
+  github_webhooks_token       = var.github_webhooks_token
+  github_webhook_events       = var.github_webhook_events
+  repo_owner                  = var.repo_owner
+  repo_name                   = var.repo_name
+  branch                      = var.branch
+  badge_enabled               = var.badge_enabled
+  build_image                 = var.build_image
+  build_compute_type          = var.codepipeline_build_compute_type
+  build_timeout               = var.build_timeout
+  buildspec                   = var.buildspec
+  cache_bucket_suffix_enabled = var.codepipeline_build_cache_bucket_suffix_enabled
+  image_repo_name             = module.ecr.repository_name
+  service_name                = module.ecs_alb_service_task.service_name
+  ecs_cluster_name            = var.ecs_cluster_name
+  privileged_mode             = true
+  poll_source_changes         = var.poll_source_changes
 
   webhook_enabled             = var.webhook_enabled
   webhook_target_action       = var.webhook_target_action

--- a/variables.tf
+++ b/variables.tf
@@ -846,6 +846,12 @@ variable "authentication_oidc_scope" {
   default     = []
 }
 
+variable "codepipeline_build_cache_bucket_suffix_enabled" {
+  type        = bool
+  description = "The codebuild cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache_type is 'S3'"
+  default     = true
+}
+
 variable "codepipeline_build_compute_type" {
   type        = string
   default     = "BUILD_GENERAL1_SMALL"


### PR DESCRIPTION
Exposes codepipelines 'cache_bucket_suffix_enabled' as 'codepipeline_build_cache_bucket_suffix_enabled'

## what
* Updates the codepipeline module to allow passing in the `cache_bucket_suffix_enabled` variable.
* Exposes the `cache_bucket_suffix_enabled` in the ecs web app module as `codepipeline_build_cache_bucket_suffix_enabled`
* `codepipeline_build_cache_bucket_suffix_enabled` defaults to `true` the current behavior.

## why
* Allows building the cache bucket without suffix
* Fixes the following error I am getting:
```bash
Error: cache location is required when cache type is "S3"

  on .terraform/modules/web.ecs_codepipeline.codebuild/main.tf line 206, in resource "aws_codebuild_project" "default":
 206: resource "aws_codebuild_project" "default" {
```

## references
* terraform-aws-ecs-codepipeline [release notes](https://github.com/cloudposse/terraform-aws-ecs-codepipeline/releases/tag/0.23.0).  

## note
Hope the variable name is acceptable...otherwise please recommend an better variable name.

