### PR TITLE
feat: update module to use new ALB ingress module

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -56,3 +56,10 @@ pull_request_rules:
       changes_requested: true
       approved: true
       message: "This Pull Request has been updated, so we're dismissing all reviews."
+
+- name: "close Pull Requests without files changed"
+  conditions:
+    - "#files=0"
+  actions:
+    close:
+      message: "This pull request has been automatically closed by Mergify because there are no longer any changes."

--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   auto-format:
     runs-on: ubuntu-latest
-    container: cloudposse/build-harness:slim-latest
+    container: cloudposse/build-harness:latest
     steps:
     # Checkout the pull request branch
     #  "An action in a workflow run can’t trigger a new workflow run. For example, if an action pushes code using
@@ -29,6 +29,8 @@ jobs:
     - name: Auto Format
       if: github.event.pull_request.state == 'open'
       shell: bash
+      env:
+        GITHUB_TOKEN: "${{ secrets.PUBLIC_REPO_ACCESS_TOKEN }}"
       run: make BUILD_HARNESS_PATH=/build-harness PACKAGES_PREFER_HOST=true -f /build-harness/templates/Makefile.build-harness pr/auto-format/host
 
     # Commit changes (if any) to the PR branch

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| alb_ingress | cloudposse/alb-ingress/aws | 0.22.1 |
+| alb_ingress | cloudposse/alb-ingress/aws | 0.23.0 |
 | alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
 | container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
 | ecr | cloudposse/ecr/aws | 0.32.2 |

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Available targets:
 
 | Name | Source | Version |
 |------|--------|---------|
-| alb_ingress | cloudposse/alb-ingress/aws | 0.20.0 |
+| alb_ingress | cloudposse/alb-ingress/aws | 0.22.1 |
 | alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
 | container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
 | ecr | cloudposse/ecr/aws | 0.32.2 |
@@ -186,7 +186,7 @@ Available targets:
 
 | Name |
 |------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
 
 ## Inputs
 
@@ -197,7 +197,6 @@ Available targets:
 | alb\_container\_name | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |
 | alb\_ingress\_authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| alb\_ingress\_authenticated\_listener\_arns\_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | alb\_ingress\_authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | alb\_ingress\_enable\_default\_target\_group | If true, create a default target group for the ALB ingress | `bool` | `true` | no |
 | alb\_ingress\_healthcheck\_path | The path of the healthcheck which the ALB checks | `string` | `"/"` | no |
@@ -207,7 +206,6 @@ Available targets:
 | alb\_ingress\_target\_group\_arn | Existing ALB target group ARN. If provided, set `alb_ingress_enable_default_target_group` to `false` to disable creation of the default target group | `string` | `""` | no |
 | alb\_ingress\_unauthenticated\_hosts | Unauthenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_unauthenticated\_listener\_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| alb\_ingress\_unauthenticated\_listener\_arns\_count | The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | alb\_ingress\_unauthenticated\_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | alb\_security\_group | Security group of the ALB | `string` | n/a | yes |
 | alb\_target\_group\_alarms\_3xx\_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service | `number` | `25` | no |
@@ -222,7 +220,7 @@ Available targets:
 | alb\_target\_group\_alarms\_response\_time\_threshold | The maximum ALB Target Group response time | `number` | `0.5` | no |
 | assign\_public\_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are `true` or `false`. Default `false` | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
+| authentication\_cognito\_scope | Cognito scope | `string` | `null` | no |
 | authentication\_cognito\_user\_pool\_arn | Cognito User Pool ARN | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_client\_id | Cognito User Pool Client ID | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | `string` | `""` | no |
@@ -230,7 +228,7 @@ Available targets:
 | authentication\_oidc\_client\_id | OIDC Client ID | `string` | `""` | no |
 | authentication\_oidc\_client\_secret | OIDC Client Secret | `string` | `""` | no |
 | authentication\_oidc\_issuer | OIDC Issuer | `string` | `""` | no |
-| authentication\_oidc\_scope | OIDC scope | `list(string)` | `[]` | no |
+| authentication\_oidc\_scope | OIDC scope | `string` | `null` | no |
 | authentication\_oidc\_token\_endpoint | OIDC Token Endpoint | `string` | `""` | no |
 | authentication\_oidc\_user\_info\_endpoint | OIDC User Info Endpoint | `string` | `""` | no |
 | authentication\_type | Authentication type. Supported values are `COGNITO` and `OIDC` | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| alb_ingress | cloudposse/alb-ingress/aws | 0.20.0 |
+| alb_ingress | cloudposse/alb-ingress/aws | 0.22.1 |
 | alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
 | container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
 | ecr | cloudposse/ecr/aws | 0.32.2 |
@@ -30,7 +30,7 @@
 
 | Name |
 |------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
 
 ## Inputs
 
@@ -41,7 +41,6 @@
 | alb\_container\_name | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |
 | alb\_ingress\_authenticated\_hosts | Authenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_authenticated\_listener\_arns | A list of authenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| alb\_ingress\_authenticated\_listener\_arns\_count | The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | alb\_ingress\_authenticated\_paths | Authenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | alb\_ingress\_enable\_default\_target\_group | If true, create a default target group for the ALB ingress | `bool` | `true` | no |
 | alb\_ingress\_healthcheck\_path | The path of the healthcheck which the ALB checks | `string` | `"/"` | no |
@@ -51,7 +50,6 @@
 | alb\_ingress\_target\_group\_arn | Existing ALB target group ARN. If provided, set `alb_ingress_enable_default_target_group` to `false` to disable creation of the default target group | `string` | `""` | no |
 | alb\_ingress\_unauthenticated\_hosts | Unauthenticated hosts to match in Hosts header | `list(string)` | `[]` | no |
 | alb\_ingress\_unauthenticated\_listener\_arns | A list of unauthenticated ALB listener ARNs to attach ALB listener rules to | `list(string)` | `[]` | no |
-| alb\_ingress\_unauthenticated\_listener\_arns\_count | The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed | `number` | `0` | no |
 | alb\_ingress\_unauthenticated\_paths | Unauthenticated path pattern to match (a maximum of 1 can be defined) | `list(string)` | `[]` | no |
 | alb\_security\_group | Security group of the ALB | `string` | n/a | yes |
 | alb\_target\_group\_alarms\_3xx\_threshold | The maximum number of 3XX HTTPCodes in a given period for ECS Service | `number` | `25` | no |
@@ -66,7 +64,7 @@
 | alb\_target\_group\_alarms\_response\_time\_threshold | The maximum ALB Target Group response time | `number` | `0.5` | no |
 | assign\_public\_ip | Assign a public IP address to the ENI (Fargate launch type only). Valid values are `true` or `false`. Default `false` | `bool` | `false` | no |
 | attributes | Additional attributes (e.g. `1`) | `list(string)` | `[]` | no |
-| authentication\_cognito\_scope | Cognito scope | `list(string)` | `[]` | no |
+| authentication\_cognito\_scope | Cognito scope | `string` | `null` | no |
 | authentication\_cognito\_user\_pool\_arn | Cognito User Pool ARN | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_client\_id | Cognito User Pool Client ID | `string` | `""` | no |
 | authentication\_cognito\_user\_pool\_domain | Cognito User Pool Domain. The User Pool Domain should be set to the domain prefix (`xxx`) instead of full domain (https://xxx.auth.us-west-2.amazoncognito.com) | `string` | `""` | no |
@@ -74,7 +72,7 @@
 | authentication\_oidc\_client\_id | OIDC Client ID | `string` | `""` | no |
 | authentication\_oidc\_client\_secret | OIDC Client Secret | `string` | `""` | no |
 | authentication\_oidc\_issuer | OIDC Issuer | `string` | `""` | no |
-| authentication\_oidc\_scope | OIDC scope | `list(string)` | `[]` | no |
+| authentication\_oidc\_scope | OIDC scope | `string` | `null` | no |
 | authentication\_oidc\_token\_endpoint | OIDC Token Endpoint | `string` | `""` | no |
 | authentication\_oidc\_user\_info\_endpoint | OIDC User Info Endpoint | `string` | `""` | no |
 | authentication\_type | Authentication type. Supported values are `COGNITO` and `OIDC` | `string` | `""` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -16,7 +16,7 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| alb_ingress | cloudposse/alb-ingress/aws | 0.22.1 |
+| alb_ingress | cloudposse/alb-ingress/aws | 0.23.0 |
 | alb_target_group_cloudwatch_sns_alarms | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.15.0 |
 | container_definition | cloudposse/ecs-container-definition/aws | 0.49.2 |
 | ecr | cloudposse/ecr/aws | 0.32.2 |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -104,11 +104,10 @@ module "ecs_web_app" {
   container_port                    = var.container_port
 
   # ALB
-  alb_arn_suffix                                  = module.alb.alb_arn_suffix
-  alb_security_group                              = module.alb.security_group_id
-  alb_ingress_unauthenticated_listener_arns       = [module.alb.http_listener_arn]
-  alb_ingress_unauthenticated_listener_arns_count = 1
-  alb_ingress_healthcheck_path                    = var.alb_ingress_healthcheck_path
+  alb_arn_suffix                            = module.alb.alb_arn_suffix
+  alb_security_group                        = module.alb.security_group_id
+  alb_ingress_unauthenticated_listener_arns = [module.alb.http_listener_arn]
+  alb_ingress_healthcheck_path              = var.alb_ingress_healthcheck_path
 
   # CodePipeline
   codepipeline_enabled                 = var.codepipeline_enabled

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -126,8 +126,7 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  alb_ingress_authenticated_listener_arns       = module.alb.https_listener_arn
-  alb_ingress_authenticated_listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns = module.alb.https_listener_arn
 
   # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -125,8 +125,7 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # NOTE: Cognito and OIDC authentication only supported on HTTPS endpoints; here we provide `https_listener_arn` from ALB
-  alb_ingress_authenticated_listener_arns       = module.alb.https_listener_arn
-  alb_ingress_authenticated_listener_arns_count = 1
+  alb_ingress_authenticated_listener_arns = module.alb.https_listener_arn
 
   # Unauthenticated paths (with higher priority than the authenticated paths)
   alb_ingress_unauthenticated_paths             = ["/events"]

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -125,8 +125,7 @@ module "web_app" {
   alb_ingress_healthcheck_path = "/"
 
   # Without authentication, both HTTP and HTTPS endpoints are supported
-  alb_ingress_unauthenticated_listener_arns       = module.alb.listener_arns
-  alb_ingress_unauthenticated_listener_arns_count = 2
+  alb_ingress_unauthenticated_listener_arns = module.alb.listener_arns
 
   # All paths are unauthenticated
   alb_ingress_unauthenticated_paths             = ["/*"]

--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_log_group" "app" {
 
 module "alb_ingress" {
   source  = "cloudposse/alb-ingress/aws"
-  version = "0.22.1"
+  version = "0.23.0"
 
   vpc_id                       = var.vpc_id
   port                         = var.container_port

--- a/main.tf
+++ b/main.tf
@@ -20,7 +20,7 @@ resource "aws_cloudwatch_log_group" "app" {
 
 module "alb_ingress" {
   source  = "cloudposse/alb-ingress/aws"
-  version = "0.20.0"
+  version = "0.22.1"
 
   vpc_id                       = var.vpc_id
   port                         = var.container_port
@@ -37,10 +37,8 @@ module "alb_ingress" {
   authenticated_priority   = var.alb_ingress_listener_authenticated_priority
   unauthenticated_priority = var.alb_ingress_listener_unauthenticated_priority
 
-  unauthenticated_listener_arns       = var.alb_ingress_unauthenticated_listener_arns
-  unauthenticated_listener_arns_count = var.alb_ingress_unauthenticated_listener_arns_count
-  authenticated_listener_arns         = var.alb_ingress_authenticated_listener_arns
-  authenticated_listener_arns_count   = var.alb_ingress_authenticated_listener_arns_count
+  unauthenticated_listener_arns = var.alb_ingress_unauthenticated_listener_arns
+  authenticated_listener_arns   = var.alb_ingress_authenticated_listener_arns
 
   authentication_type                        = var.authentication_type
   authentication_cognito_user_pool_arn       = var.authentication_cognito_user_pool_arn

--- a/variables.tf
+++ b/variables.tf
@@ -756,22 +756,10 @@ variable "alb_ingress_unauthenticated_listener_arns" {
   default     = []
 }
 
-variable "alb_ingress_unauthenticated_listener_arns_count" {
-  type        = number
-  description = "The number of unauthenticated ARNs in `alb_ingress_unauthenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
-  default     = 0
-}
-
 variable "alb_ingress_authenticated_listener_arns" {
   type        = list(string)
   description = "A list of authenticated ALB listener ARNs to attach ALB listener rules to"
   default     = []
-}
-
-variable "alb_ingress_authenticated_listener_arns_count" {
-  type        = number
-  description = "The number of authenticated ARNs in `alb_ingress_authenticated_listener_arns`. This is necessary to work around a limitation in Terraform where counts cannot be computed"
-  default     = 0
 }
 
 variable "authentication_type" {
@@ -799,9 +787,9 @@ variable "authentication_cognito_user_pool_domain" {
 }
 
 variable "authentication_cognito_scope" {
-  type        = list(string)
+  type        = string
   description = "Cognito scope"
-  default     = []
+  default     = null
 }
 
 variable "authentication_oidc_client_id" {
@@ -841,9 +829,9 @@ variable "authentication_oidc_user_info_endpoint" {
 }
 
 variable "authentication_oidc_scope" {
-  type        = list(string)
+  type        = string
   description = "OIDC scope"
-  default     = []
+  default     = null
 }
 
 variable "codepipeline_build_cache_bucket_suffix_enabled" {


### PR DESCRIPTION
This change updates the ALB ingress module so that we can pass the OIDC
scope setting through unaltered.

Fixes #90.

## what
* Update the module to use the latest alb-ingress module, which passes through the OIDC scopes as a string

## why
* Be compatible with the scope changes in the alb-ingress module, which were meant to reduce the burden on the module for properly formatted scope strings 

## references
* https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/90

