### PR TITLE
Fewer required variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,8 @@ Available targets:
 
 | Name |
 |------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 
 ## Inputs
 
@@ -243,7 +244,7 @@ Available targets:
 | autoscaling\_scale\_up\_adjustment | Scaling adjustment to make during scale up event | `number` | `1` | no |
 | autoscaling\_scale\_up\_cooldown | Period (in seconds) to wait between scale up events | `number` | `60` | no |
 | aws\_logs\_prefix | Custom AWS Logs prefix. If empty name from label module will be used | `string` | `""` | no |
-| aws\_logs\_region | The region for the AWS Cloudwatch Logs group | `string` | n/a | yes |
+| aws\_logs\_region | The region for the AWS Cloudwatch Logs group | `string` | `null` | no |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | branch | Branch of the GitHub repository, e.g. `master` | `string` | `""` | no |
 | build\_environment\_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>  }))</pre> | `[]` | no |
@@ -294,7 +295,7 @@ Available targets:
 | ecs\_alarms\_memory\_utilization\_low\_period | Duration in seconds to evaluate for the alarm | `number` | `300` | no |
 | ecs\_alarms\_memory\_utilization\_low\_threshold | The minimum percentage of Memory utilization average | `number` | `20` | no |
 | ecs\_cluster\_arn | The ECS Cluster ARN where ECS Service will be provisioned | `string` | n/a | yes |
-| ecs\_cluster\_name | The ECS Cluster Name to use in ECS Code Pipeline Deployment step | `string` | n/a | yes |
+| ecs\_cluster\_name | The ECS Cluster Name to use in ECS Code Pipeline Deployment step | `string` | `null` | no |
 | ecs\_private\_subnet\_ids | List of Private Subnet IDs to provision ECS Service onto | `list(string)` | n/a | yes |
 | ecs\_security\_group\_ids | Additional Security Group IDs to allow into ECS Service | `list(string)` | `[]` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -327,7 +328,7 @@ Available targets:
 | port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | <pre>list(object({<br>    containerPort = number<br>    hostPort      = number<br>    protocol      = string<br>  }))</pre> | <pre>[<br>  {<br>    "containerPort": 80,<br>    "hostPort": 80,<br>    "protocol": "tcp"<br>  }<br>]</pre> | no |
 | privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
+| region | AWS Region for S3 bucket | `string` | `null` | no |
 | repo\_name | GitHub repository name of the application to be built and deployed to ECS | `string` | `""` | no |
 | repo\_owner | GitHub Organization or Username | `string` | `""` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -30,7 +30,8 @@
 
 | Name |
 |------|
-| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/2.0/docs/resources/cloudwatch_log_group) |
+| [aws_cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) |
+| [aws_region](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) |
 
 ## Inputs
 
@@ -87,7 +88,7 @@
 | autoscaling\_scale\_up\_adjustment | Scaling adjustment to make during scale up event | `number` | `1` | no |
 | autoscaling\_scale\_up\_cooldown | Period (in seconds) to wait between scale up events | `number` | `60` | no |
 | aws\_logs\_prefix | Custom AWS Logs prefix. If empty name from label module will be used | `string` | `""` | no |
-| aws\_logs\_region | The region for the AWS Cloudwatch Logs group | `string` | n/a | yes |
+| aws\_logs\_region | The region for the AWS Cloudwatch Logs group | `string` | `null` | no |
 | badge\_enabled | Generates a publicly-accessible URL for the projects build badge. Available as badge\_url attribute when enabled | `bool` | `false` | no |
 | branch | Branch of the GitHub repository, e.g. `master` | `string` | `""` | no |
 | build\_environment\_variables | A list of maps, that contain both the key 'name' and the key 'value' to be used as additional environment variables for the build | <pre>list(object(<br>    {<br>      name  = string<br>      value = string<br>  }))</pre> | `[]` | no |
@@ -138,7 +139,7 @@
 | ecs\_alarms\_memory\_utilization\_low\_period | Duration in seconds to evaluate for the alarm | `number` | `300` | no |
 | ecs\_alarms\_memory\_utilization\_low\_threshold | The minimum percentage of Memory utilization average | `number` | `20` | no |
 | ecs\_cluster\_arn | The ECS Cluster ARN where ECS Service will be provisioned | `string` | n/a | yes |
-| ecs\_cluster\_name | The ECS Cluster Name to use in ECS Code Pipeline Deployment step | `string` | n/a | yes |
+| ecs\_cluster\_name | The ECS Cluster Name to use in ECS Code Pipeline Deployment step | `string` | `null` | no |
 | ecs\_private\_subnet\_ids | List of Private Subnet IDs to provision ECS Service onto | `list(string)` | n/a | yes |
 | ecs\_security\_group\_ids | Additional Security Group IDs to allow into ECS Service | `list(string)` | `[]` | no |
 | enabled | Set to false to prevent the module from creating any resources | `bool` | `null` | no |
@@ -171,7 +172,7 @@
 | port\_mappings | The port mappings to configure for the container. This is a list of maps. Each map should contain "containerPort", "hostPort", and "protocol", where "protocol" is one of "tcp" or "udp". If using containers in a task with the awsvpc or host network mode, the hostPort can either be left blank or set to the same value as the containerPort | <pre>list(object({<br>    containerPort = number<br>    hostPort      = number<br>    protocol      = string<br>  }))</pre> | <pre>[<br>  {<br>    "containerPort": 80,<br>    "hostPort": 80,<br>    "protocol": "tcp"<br>  }<br>]</pre> | no |
 | privileged | When this variable is `true`, the container is given elevated privileges on the host container instance (similar to the root user). This parameter is not supported for Windows containers or tasks using the Fargate launch type. Due to how Terraform type casts booleans in json it is required to double quote this value | `string` | `null` | no |
 | regex\_replace\_chars | Regex to replace chars with empty string in `namespace`, `environment`, `stage` and `name`.<br>If not set, `"/[^a-zA-Z0-9-]/"` is used to remove all characters other than hyphens, letters and digits. | `string` | `null` | no |
-| region | AWS Region for S3 bucket | `string` | n/a | yes |
+| region | AWS Region for S3 bucket | `string` | `null` | no |
 | repo\_name | GitHub repository name of the application to be built and deployed to ECS | `string` | `""` | no |
 | repo\_owner | GitHub Organization or Username | `string` | `""` | no |
 | secrets | The secrets to pass to the container. This is a list of maps | <pre>list(object({<br>    name      = string<br>    valueFrom = string<br>  }))</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,5 @@
+data "aws_region" "current" {}
+
 module "ecr" {
   source  = "cloudposse/ecr/aws"
   version = "0.32.2"
@@ -84,7 +86,7 @@ module "container_definition" {
   log_configuration = var.cloudwatch_log_group_enabled ? {
     logDriver = var.log_driver
     options = {
-      "awslogs-region"        = var.aws_logs_region
+      "awslogs-region"        = coalesce(var.aws_logs_region, data.aws_region.current.name)
       "awslogs-group"         = join("", aws_cloudwatch_log_group.app.*.name)
       "awslogs-stream-prefix" = var.aws_logs_prefix == "" ? module.this.name : var.aws_logs_prefix
     }
@@ -161,7 +163,7 @@ module "ecs_codepipeline" {
   source  = "cloudposse/ecs-codepipeline/aws"
   version = "0.23.0"
 
-  region                      = var.region
+  region                      = coalesce(var.region, data.aws_region.current.name)
   github_oauth_token          = var.github_oauth_token
   github_webhooks_token       = var.github_webhooks_token
   github_webhook_events       = var.github_webhook_events

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,7 @@
 variable "region" {
   type        = string
   description = "AWS Region for S3 bucket"
+  default     = null
 }
 
 variable "codepipeline_enabled" {
@@ -422,7 +423,7 @@ variable "vpc_id" {
 variable "aws_logs_region" {
   type        = string
   description = "The region for the AWS Cloudwatch Logs group"
-}
+  default     = null
 
 variable "aws_logs_prefix" {
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -462,6 +462,7 @@ variable "ecs_cluster_arn" {
 variable "ecs_cluster_name" {
   type        = string
   description = "The ECS Cluster Name to use in ECS Code Pipeline Deployment step"
+  default     = null
 }
 
 variable "ecs_alarms_cpu_utilization_high_threshold" {

--- a/variables.tf
+++ b/variables.tf
@@ -424,6 +424,7 @@ variable "aws_logs_region" {
   type        = string
   description = "The region for the AWS Cloudwatch Logs group"
   default     = null
+}
 
 variable "aws_logs_prefix" {
   type        = string


### PR DESCRIPTION
## what
* Added 3 variable defaults. The ecs cluster name is only required if codepipeline is enabled.
* The region variables don't need to be specified when the current aws region could be provided as a default

## why
* Simplifies usage of the module

## references
N/A
