### PR TITLE
feat: add optional CDN to codepipeline deploy

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ Available targets:
 | ecs_alb_service_task | cloudposse/ecs-alb-service-task/aws | 0.47.0 |
 | ecs_cloudwatch_autoscaling | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.0 |
 | ecs_cloudwatch_sns_alarms | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.1 |
-| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.23.0 |
+| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.24.0 |
 | this | cloudposse/label/null | 0.24.1 |
 
 ## Resources
@@ -255,6 +255,9 @@ Available targets:
 | cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
 | codepipeline\_build\_cache\_bucket\_suffix\_enabled | The codebuild cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
+| codepipeline\_cdn\_bucket\_buildspec\_identifier | Identifier for buildspec section controlling the optional CDN asset deployment. | `string` | `null` | no |
+| codepipeline\_cdn\_bucket\_encryption\_enabled | If set to true, enable encryption on the optional CDN asset deployment bucket | `bool` | `false` | no |
+| codepipeline\_cdn\_bucket\_id | Optional bucket for static asset deployment. If specified, the buildspec must include a secondary artifacts section which controls the files deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -23,7 +23,7 @@
 | ecs_alb_service_task | cloudposse/ecs-alb-service-task/aws | 0.47.0 |
 | ecs_cloudwatch_autoscaling | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.0 |
 | ecs_cloudwatch_sns_alarms | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.1 |
-| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.23.0 |
+| ecs_codepipeline | cloudposse/ecs-codepipeline/aws | 0.24.0 |
 | this | cloudposse/label/null | 0.24.1 |
 
 ## Resources
@@ -99,6 +99,9 @@
 | cloudwatch\_log\_group\_enabled | A boolean to disable cloudwatch log group creation | `bool` | `true` | no |
 | codepipeline\_build\_cache\_bucket\_suffix\_enabled | The codebuild cache bucket generates a random 13 character string to generate a unique bucket name. If set to false it uses terraform-null-label's id value. It only works when cache\_type is 'S3' | `bool` | `true` | no |
 | codepipeline\_build\_compute\_type | `CodeBuild` instance size. Possible values are: `BUILD_GENERAL1_SMALL` `BUILD_GENERAL1_MEDIUM` `BUILD_GENERAL1_LARGE` | `string` | `"BUILD_GENERAL1_SMALL"` | no |
+| codepipeline\_cdn\_bucket\_buildspec\_identifier | Identifier for buildspec section controlling the optional CDN asset deployment. | `string` | `null` | no |
+| codepipeline\_cdn\_bucket\_encryption\_enabled | If set to true, enable encryption on the optional CDN asset deployment bucket | `bool` | `false` | no |
+| codepipeline\_cdn\_bucket\_id | Optional bucket for static asset deployment. If specified, the buildspec must include a secondary artifacts section which controls the files deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | codepipeline\_enabled | A boolean to enable/disable AWS Codepipeline and ECR | `bool` | `true` | no |
 | codepipeline\_s3\_bucket\_force\_destroy | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
 | command | The command that is passed to the container | `list(string)` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -161,7 +161,7 @@ module "ecs_alb_service_task" {
 module "ecs_codepipeline" {
   enabled = var.codepipeline_enabled
   source  = "cloudposse/ecs-codepipeline/aws"
-  version = "0.23.0"
+  version = "0.24.0"
 
   region                      = coalesce(var.region, data.aws_region.current.name)
   github_oauth_token          = var.github_oauth_token
@@ -181,6 +181,10 @@ module "ecs_codepipeline" {
   ecs_cluster_name            = var.ecs_cluster_name
   privileged_mode             = true
   poll_source_changes         = var.poll_source_changes
+
+  secondary_artifact_bucket_id          = var.codepipeline_cdn_bucket_id
+  secondary_artifact_encryption_enabled = var.codepipeline_cdn_bucket_encryption_enabled
+  secondary_artifact_identifier         = var.codepipeline_cdn_bucket_buildspec_identifier
 
   webhook_enabled             = var.webhook_enabled
   webhook_target_action       = var.webhook_target_action

--- a/variables.tf
+++ b/variables.tf
@@ -10,6 +10,24 @@ variable "codepipeline_enabled" {
   default     = true
 }
 
+variable "codepipeline_cdn_bucket_id" {
+  type        = string
+  default     = null
+  description = "Optional bucket for static asset deployment. If specified, the buildspec must include a secondary artifacts section which controls the files deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html)"
+}
+
+variable "codepipeline_cdn_bucket_encryption_enabled" {
+  type        = bool
+  default     = false
+  description = "If set to true, enable encryption on the optional CDN asset deployment bucket"
+}
+
+variable "codepipeline_cdn_bucket_buildspec_identifier" {
+  type        = string
+  default     = null
+  description = "Identifier for buildspec section controlling the optional CDN asset deployment."
+}
+
 variable "use_ecr_image" {
   type        = bool
   description = "If true, use ECR repo URL for image, otherwise use value in container_image"


### PR DESCRIPTION
## what
* Update the module to use the latest [terraform-aws-ecs-codepipeline](https://github.com/cloudposse/terraform-aws-ecs-codepipeline) module, and pass through configuration settings for secondary artifacts

## why
The update will allow the settings on the child module to be configured. The intent is to allow a single buildspec file to deploy static assets to an S3 CDN.

## references
* https://github.com/cloudposse/terraform-aws-ecs-codepipeline/pull/73

