### PR TITLE
Support declaring individual efs, docker, fsx volumes for tasks

### DIFF
--- a/variables-deprecated.tf
+++ b/variables-deprecated.tf
@@ -1,0 +1,30 @@
+variable "volumes" {
+  type = list(object({
+    host_path = string
+    name      = string
+    docker_volume_configuration = list(object({
+      autoprovision = bool
+      driver        = string
+      driver_opts   = map(string)
+      labels        = map(string)
+      scope         = string
+    }))
+    efs_volume_configuration = list(object({
+      file_system_id          = string
+      root_directory          = string
+      transit_encryption      = string
+      transit_encryption_port = string
+      authorization_config = list(object({
+        access_point_id = string
+        iam             = string
+      }))
+    }))
+  }))
+  description = <<-EOT
+    DEPRECATED: Use any of `efs_volumes`, `docker_volumes`, `fsx_volumes`, instead.
+    Historical description: Task volume definitions as list of configuration objects.
+    Historical default: `[]`
+    EOT
+
+  default = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -217,17 +217,10 @@ variable "service_registries" {
   default     = []
 }
 
-variable "volumes" {
+variable "efs_volumes" {
   type = list(object({
     host_path = string
     name      = string
-    docker_volume_configuration = list(object({
-      autoprovision = bool
-      driver        = string
-      driver_opts   = map(string)
-      labels        = map(string)
-      scope         = string
-    }))
     efs_volume_configuration = list(object({
       file_system_id          = string
       root_directory          = string
@@ -239,7 +232,43 @@ variable "volumes" {
       }))
     }))
   }))
-  description = "Task volume definitions as list of configuration objects"
+
+  description = "Task EFS volume definitions as list of configuration objects. You can define multiple EFS volumes on the same task definition, but a single volume can only have one `efs_volume_configuration`."
+  default     = []
+}
+
+variable "docker_volumes" {
+  type = list(object({
+    host_path = string
+    name      = string
+    docker_volume_configuration = list(object({
+      autoprovision = bool
+      driver        = string
+      driver_opts   = map(string)
+      labels        = map(string)
+      scope         = string
+    }))
+  }))
+
+  description = "Task docker volume definitions as list of configuration objects. You can define multiple Docker volumes on the same task definition, but a single volume can only have one `docker_volume_configuration`."
+  default     = []
+}
+
+variable "fsx_volumes" {
+  type = list(object({
+    host_path = string
+    name      = string
+    fsx_windows_file_server_volume_configuration = list(object({
+      file_system_id = string
+      root_directory = string
+      authorization_config = list(object({
+        credentials_parameter = string
+        domain                = string
+      }))
+    }))
+  }))
+
+  description = "Task FSx volume definitions as list of configuration objects. You can define multiple FSx volumes on the same task definition, but a single volume can only have one `fsx_windows_file_server_volume_configuration`."
   default     = []
 }
 


### PR DESCRIPTION
## what

* Supports declaring separate volumes for efs, docker, and fsx
* This also decouples name and host_path which are expected to be passed uniquely in each volume variable declaration
* Maintains backwards compatibility by pulling apart the deprecated volumes variable into the new expected format

## why
* [terraform-aws-ecs-alb-service-task](https://github.com/cloudposse/terraform-aws-ecs-alb-service-task) expects each of efs, docker, and fsx volumes to be passed separately
* Also expects name and host_port to be declared in each of the volume variable declarations
* Also allows for support for FSX volumes which are supported in the service-task module but not in this one.

## references

* https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/205 partially implements this functionality but does not preserve backwards compatibility and does not setup FSX volumes

