### PR TITLE
feat: add CodeStar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,6 @@ We highly recommend that in your code you pin the version to the exact version y
 using so that your infrastructure remains stable, and update versions in a
 systematic way so that they do not catch you by surprise.
 
-Also, because of a bug in the Terraform registry ([hashicorp/terraform#21417](https://github.com/hashicorp/terraform/issues/21417)),
-the registry shows many of our inputs as required when in fact they are optional.
-The table below correctly indicates which inputs are required.
-
 
 For a complete example, see [examples/complete](examples/complete).
 
@@ -159,13 +155,13 @@ Available targets:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34, < 5.0 |
 
 ## Modules
 
@@ -178,7 +174,7 @@ Available targets:
 | <a name="module_ecs_alb_service_task"></a> [ecs\_alb\_service\_task](#module\_ecs\_alb\_service\_task) | cloudposse/ecs-alb-service-task/aws | 0.64.1 |
 | <a name="module_ecs_cloudwatch_autoscaling"></a> [ecs\_cloudwatch\_autoscaling](#module\_ecs\_cloudwatch\_autoscaling) | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.3 |
 | <a name="module_ecs_cloudwatch_sns_alarms"></a> [ecs\_cloudwatch\_sns\_alarms](#module\_ecs\_cloudwatch\_sns\_alarms) | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.2 |
-| <a name="module_ecs_codepipeline"></a> [ecs\_codepipeline](#module\_ecs\_codepipeline) | cloudposse/ecs-codepipeline/aws | 0.30.0 |
+| <a name="module_ecs_codepipeline"></a> [ecs\_codepipeline](#module\_ecs\_codepipeline) | cloudposse/ecs-codepipeline/aws | 0.33.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -272,6 +268,8 @@ Available targets:
 | <a name="input_codepipeline_cdn_bucket_id"></a> [codepipeline\_cdn\_bucket\_id](#input\_codepipeline\_cdn\_bucket\_id) | Optional bucket for static asset deployment. If specified, the buildspec must include a secondary artifacts section which controls the files deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | <a name="input_codepipeline_enabled"></a> [codepipeline\_enabled](#input\_codepipeline\_enabled) | A boolean to enable/disable AWS Codepipeline. If `false`, use `ecr_enabled` to control if AWS ECR stays enabled. | `bool` | `true` | no |
 | <a name="input_codepipeline_s3_bucket_force_destroy"></a> [codepipeline\_s3\_bucket\_force\_destroy](#input\_codepipeline\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| <a name="input_codestar_connection_arn"></a> [codestar\_connection\_arn](#input\_codestar\_connection\_arn) | CodeStar connection ARN required for Bitbucket / GitHub integration with CodePipeline | `string` | `""` | no |
+| <a name="input_codestar_output_artifact_format"></a> [codestar\_output\_artifact\_format](#input\_codestar\_output\_artifact\_format) | Output artifact type for Source stage in pipeline. Valid values are "CODE\_ZIP" (default) and "CODEBUILD\_CLONE\_REF". See https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html | `string` | `"CODE_ZIP"` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command that is passed to the container | `list(string)` | `null` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
 | <a name="input_container_definition"></a> [container\_definition](#input\_container\_definition) | Override the main container\_definition | `string` | `""` | no |
@@ -328,7 +326,6 @@ Available targets:
 | <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Enable to force a new task deployment of the service. | `bool` | `false` | no |
 | <a name="input_github_oauth_token"></a> [github\_oauth\_token](#input\_github\_oauth\_token) | GitHub Oauth Token with permissions to access private repositories | `string` | `""` | no |
 | <a name="input_github_webhook_events"></a> [github\_webhook\_events](#input\_github\_webhook\_events) | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | `list(string)` | <pre>[<br>  "push"<br>]</pre> | no |
-| <a name="input_github_webhooks_token"></a> [github\_webhooks\_token](#input\_github\_webhooks\_token) | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |
 | <a name="input_health_check_grace_period_seconds"></a> [health\_check\_grace\_period\_seconds](#input\_health\_check\_grace\_period\_seconds) | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | `number` | `0` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.34, < 5.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.34, < 5.0 |
 
 ## Modules
 
@@ -23,7 +23,7 @@
 | <a name="module_ecs_alb_service_task"></a> [ecs\_alb\_service\_task](#module\_ecs\_alb\_service\_task) | cloudposse/ecs-alb-service-task/aws | 0.64.1 |
 | <a name="module_ecs_cloudwatch_autoscaling"></a> [ecs\_cloudwatch\_autoscaling](#module\_ecs\_cloudwatch\_autoscaling) | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.3 |
 | <a name="module_ecs_cloudwatch_sns_alarms"></a> [ecs\_cloudwatch\_sns\_alarms](#module\_ecs\_cloudwatch\_sns\_alarms) | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.2 |
-| <a name="module_ecs_codepipeline"></a> [ecs\_codepipeline](#module\_ecs\_codepipeline) | cloudposse/ecs-codepipeline/aws | 0.30.0 |
+| <a name="module_ecs_codepipeline"></a> [ecs\_codepipeline](#module\_ecs\_codepipeline) | cloudposse/ecs-codepipeline/aws | 0.33.0 |
 | <a name="module_this"></a> [this](#module\_this) | cloudposse/label/null | 0.25.0 |
 
 ## Resources
@@ -117,6 +117,8 @@
 | <a name="input_codepipeline_cdn_bucket_id"></a> [codepipeline\_cdn\_bucket\_id](#input\_codepipeline\_cdn\_bucket\_id) | Optional bucket for static asset deployment. If specified, the buildspec must include a secondary artifacts section which controls the files deployed to the bucket [For more info](http://docs.aws.amazon.com/codebuild/latest/userguide/build-spec-ref.html) | `string` | `null` | no |
 | <a name="input_codepipeline_enabled"></a> [codepipeline\_enabled](#input\_codepipeline\_enabled) | A boolean to enable/disable AWS Codepipeline. If `false`, use `ecr_enabled` to control if AWS ECR stays enabled. | `bool` | `true` | no |
 | <a name="input_codepipeline_s3_bucket_force_destroy"></a> [codepipeline\_s3\_bucket\_force\_destroy](#input\_codepipeline\_s3\_bucket\_force\_destroy) | A boolean that indicates all objects should be deleted from the CodePipeline artifact store S3 bucket so that the bucket can be destroyed without error | `bool` | `false` | no |
+| <a name="input_codestar_connection_arn"></a> [codestar\_connection\_arn](#input\_codestar\_connection\_arn) | CodeStar connection ARN required for Bitbucket / GitHub integration with CodePipeline | `string` | `""` | no |
+| <a name="input_codestar_output_artifact_format"></a> [codestar\_output\_artifact\_format](#input\_codestar\_output\_artifact\_format) | Output artifact type for Source stage in pipeline. Valid values are "CODE\_ZIP" (default) and "CODEBUILD\_CLONE\_REF". See https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html | `string` | `"CODE_ZIP"` | no |
 | <a name="input_command"></a> [command](#input\_command) | The command that is passed to the container | `list(string)` | `null` | no |
 | <a name="input_container_cpu"></a> [container\_cpu](#input\_container\_cpu) | The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html) | `number` | `256` | no |
 | <a name="input_container_definition"></a> [container\_definition](#input\_container\_definition) | Override the main container\_definition | `string` | `""` | no |
@@ -173,7 +175,6 @@
 | <a name="input_force_new_deployment"></a> [force\_new\_deployment](#input\_force\_new\_deployment) | Enable to force a new task deployment of the service. | `bool` | `false` | no |
 | <a name="input_github_oauth_token"></a> [github\_oauth\_token](#input\_github\_oauth\_token) | GitHub Oauth Token with permissions to access private repositories | `string` | `""` | no |
 | <a name="input_github_webhook_events"></a> [github\_webhook\_events](#input\_github\_webhook\_events) | A list of events which should trigger the webhook. See a list of [available events](https://developer.github.com/v3/activity/events/types/) | `list(string)` | <pre>[<br>  "push"<br>]</pre> | no |
-| <a name="input_github_webhooks_token"></a> [github\_webhooks\_token](#input\_github\_webhooks\_token) | GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable | `string` | `""` | no |
 | <a name="input_health_check_grace_period_seconds"></a> [health\_check\_grace\_period\_seconds](#input\_health\_check\_grace\_period\_seconds) | Seconds to ignore failing load balancer health checks on newly instantiated tasks to prevent premature shutdown, up to 7200. Only valid for services configured to use load balancers | `number` | `0` | no |
 | <a name="input_healthcheck"></a> [healthcheck](#input\_healthcheck) | A map containing command (string), timeout, interval (duration in seconds), retries (1-10, number of times to retry before marking container unhealthy), and startPeriod (0-300, optional grace period to wait, in seconds, before failed healthchecks count toward retries) | <pre>object({<br>    command     = list(string)<br>    retries     = number<br>    timeout     = number<br>    interval    = number<br>    startPeriod = number<br>  })</pre> | `null` | no |
 | <a name="input_id_length_limit"></a> [id\_length\_limit](#input\_id\_length\_limit) | Limit `id` to this many characters (minimum 6).<br>Set to `0` for unlimited length.<br>Set to `null` for keep the existing setting, which defaults to `0`.<br>Does not affect `id_full`. | `number` | `null` | no |

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,9 +3,9 @@ provider "aws" {
 }
 
 module "vpc" {
-  source     = "cloudposse/vpc/aws"
-  version    = "0.18.2"
-  cidr_block = var.vpc_cidr_block
+  source                  = "cloudposse/vpc/aws"
+  version                 = "2.1.0"
+  ipv4_primary_cidr_block = var.vpc_cidr_block
 
   context = module.this.context
 
@@ -13,11 +13,11 @@ module "vpc" {
 
 module "subnets" {
   source                   = "cloudposse/dynamic-subnets/aws"
-  version                  = "0.34.0"
+  version                  = "2.3.0"
   availability_zones       = var.availability_zones
   vpc_id                   = module.vpc.vpc_id
-  igw_id                   = module.vpc.igw_id
-  cidr_block               = module.vpc.vpc_cidr_block
+  igw_id                   = [module.vpc.igw_id]
+  ipv4_cidr_block          = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled      = true
   nat_instance_enabled     = false
   aws_route_create_timeout = "5m"
@@ -27,18 +27,19 @@ module "subnets" {
 }
 
 module "alb" {
-  source                                  = "cloudposse/alb/aws"
-  version                                 = "0.27.0"
-  vpc_id                                  = module.vpc.vpc_id
-  security_group_ids                      = [module.vpc.vpc_default_security_group_id]
-  subnet_ids                              = module.subnets.public_subnet_ids
-  internal                                = false
-  http_enabled                            = true
-  access_logs_enabled                     = true
-  alb_access_logs_s3_bucket_force_destroy = true
-  cross_zone_load_balancing_enabled       = true
-  http2_enabled                           = true
-  deletion_protection_enabled             = false
+  source                                          = "cloudposse/alb/aws"
+  version                                         = "1.7.0"
+  vpc_id                                          = module.vpc.vpc_id
+  security_group_ids                              = [module.vpc.vpc_default_security_group_id]
+  subnet_ids                                      = module.subnets.public_subnet_ids
+  internal                                        = false
+  http_enabled                                    = true
+  access_logs_enabled                             = true
+  alb_access_logs_s3_bucket_force_destroy         = true
+  alb_access_logs_s3_bucket_force_destroy_enabled = true
+  cross_zone_load_balancing_enabled               = true
+  http2_enabled                                   = true
+  deletion_protection_enabled                     = false
 
   context = module.this.context
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -96,11 +96,13 @@ output "alb_ingress_target_group_arn_suffix" {
 output "container_definition_json" {
   description = "JSON encoded list of container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = module.ecs_web_app.container_definition_json
+  sensitive   = true
 }
 
 output "container_definition_json_map" {
   description = "JSON encoded container definitions for use with other terraform resources such as aws_ecs_task_definition"
   value       = module.ecs_web_app.container_definition_json_map
+  sensitive   = true
 }
 
 output "ecs_exec_role_policy_id" {

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/examples/with_cognito_authentication/main.tf
+++ b/examples/with_cognito_authentication/main.tf
@@ -4,9 +4,9 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.18.0"
+  version = "2.1.0"
 
-  cidr_block = "172.16.0.0/16"
+  ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context
 }
@@ -20,11 +20,11 @@ locals {
 
 module "subnets" {
   source                   = "cloudposse/dynamic-subnets/aws"
-  version                  = "0.32.0"
+  version                  = "2.3.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
-  igw_id                   = module.vpc.igw_id
-  cidr_block               = module.vpc.vpc_cidr_block
+  igw_id                   = [module.vpc.igw_id]
+  ipv4_cidr_block          = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled      = true
   nat_instance_enabled     = false
   aws_route_create_timeout = "5m"
@@ -35,7 +35,7 @@ module "subnets" {
 
 module "alb" {
   source                                  = "cloudposse/alb/aws"
-  version                                 = "0.23.0"
+  version                                 = "1.7.0"
   vpc_id                                  = module.vpc.vpc_id
   security_group_ids                      = [module.vpc.vpc_default_security_group_id]
   subnet_ids                              = module.subnets.public_subnet_ids

--- a/examples/with_cognito_authentication/versions.tf
+++ b/examples/with_cognito_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/examples/with_google_oidc_authentication/main.tf
+++ b/examples/with_google_oidc_authentication/main.tf
@@ -4,9 +4,9 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.18.0"
+  version = "2.1.0"
 
-  cidr_block = "172.16.0.0/16"
+  ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context
 }
@@ -20,11 +20,11 @@ locals {
 
 module "subnets" {
   source                   = "cloudposse/dynamic-subnets/aws"
-  version                  = "0.32.0"
+  version                  = "2.3.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
-  igw_id                   = module.vpc.igw_id
-  cidr_block               = module.vpc.vpc_cidr_block
+  igw_id                   = [module.vpc.igw_id]
+  ipv4_cidr_block          = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled      = true
   nat_instance_enabled     = false
   aws_route_create_timeout = "5m"
@@ -35,7 +35,7 @@ module "subnets" {
 
 module "alb" {
   source                    = "cloudposse/alb/aws"
-  version                   = "0.23.0"
+  version                   = "1.7.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/with_google_oidc_authentication/versions.tf
+++ b/examples/with_google_oidc_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/examples/without_authentication/main.tf
+++ b/examples/without_authentication/main.tf
@@ -4,9 +4,9 @@ provider "aws" {
 
 module "vpc" {
   source  = "cloudposse/vpc/aws"
-  version = "0.18.0"
+  version = "2.1.0"
 
-  cidr_block = "172.16.0.0/16"
+  ipv4_primary_cidr_block = "172.16.0.0/16"
 
   context = module.this.context
 }
@@ -20,11 +20,11 @@ locals {
 
 module "subnets" {
   source                   = "cloudposse/dynamic-subnets/aws"
-  version                  = "0.32.0"
+  version                  = "2.3.0"
   availability_zones       = local.availability_zones
   vpc_id                   = module.vpc.vpc_id
-  igw_id                   = module.vpc.igw_id
-  cidr_block               = module.vpc.vpc_cidr_block
+  igw_id                   = [module.vpc.igw_id]
+  ipv4_cidr_block          = [module.vpc.vpc_cidr_block]
   nat_gateway_enabled      = true
   nat_instance_enabled     = false
   aws_route_create_timeout = "5m"
@@ -35,7 +35,7 @@ module "subnets" {
 
 module "alb" {
   source                    = "cloudposse/alb/aws"
-  version                   = "0.23.0"
+  version                   = "1.7.0"
   vpc_id                    = module.vpc.vpc_id
   ip_address_type           = "ipv4"
   subnet_ids                = module.subnets.public_subnet_ids

--- a/examples/without_authentication/versions.tf
+++ b/examples/without_authentication/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 1.1.0"
 
   required_providers {
     aws = {

--- a/main.tf
+++ b/main.tf
@@ -188,27 +188,29 @@ module "ecs_alb_service_task" {
 
 module "ecs_codepipeline" {
   enabled = var.codepipeline_enabled
+  #source  = "git::git@github.com:thoroai/terraform-aws-ecs-codepipeline.git?ref=feat/add-github-codestar-support"
   source  = "cloudposse/ecs-codepipeline/aws"
-  version = "0.30.0"
+  version = "0.33.0"
 
-  region                      = coalesce(var.region, data.aws_region.current.name)
-  github_oauth_token          = var.github_oauth_token
-  github_webhooks_token       = var.github_webhooks_token
-  github_webhook_events       = var.github_webhook_events
-  repo_owner                  = var.repo_owner
-  repo_name                   = var.repo_name
-  branch                      = var.branch
-  badge_enabled               = var.badge_enabled
-  build_image                 = var.build_image
-  build_compute_type          = var.codepipeline_build_compute_type
-  build_timeout               = var.build_timeout
-  buildspec                   = var.buildspec
-  cache_bucket_suffix_enabled = var.codepipeline_build_cache_bucket_suffix_enabled
-  image_repo_name             = module.ecr.repository_name
-  service_name                = module.ecs_alb_service_task.service_name
-  ecs_cluster_name            = var.ecs_cluster_name
-  privileged_mode             = true
-  poll_source_changes         = var.poll_source_changes
+  region                          = coalesce(var.region, data.aws_region.current.name)
+  codestar_connection_arn         = var.codestar_connection_arn
+  codestar_output_artifact_format = var.codestar_output_artifact_format
+  github_oauth_token              = var.github_oauth_token
+  github_webhook_events           = var.github_webhook_events
+  repo_owner                      = var.repo_owner
+  repo_name                       = var.repo_name
+  branch                          = var.branch
+  badge_enabled                   = var.badge_enabled
+  build_image                     = var.build_image
+  build_compute_type              = var.codepipeline_build_compute_type
+  build_timeout                   = var.build_timeout
+  buildspec                       = var.buildspec
+  cache_bucket_suffix_enabled     = var.codepipeline_build_cache_bucket_suffix_enabled
+  image_repo_name                 = module.ecr.repository_name
+  service_name                    = module.ecs_alb_service_task.service_name
+  ecs_cluster_name                = var.ecs_cluster_name
+  privileged_mode                 = true
+  poll_source_changes             = var.poll_source_changes
 
   secondary_artifact_bucket_id          = var.codepipeline_cdn_bucket_id
   secondary_artifact_encryption_enabled = var.codepipeline_cdn_bucket_encryption_enabled

--- a/variables.tf
+++ b/variables.tf
@@ -725,15 +725,21 @@ variable "ecs_private_subnet_ids" {
   description = "List of Private Subnet IDs to provision ECS Service onto if `var.network_mode = \"awsvpc\"`"
 }
 
-variable "github_oauth_token" {
+variable "codestar_connection_arn" {
   type        = string
-  description = "GitHub Oauth Token with permissions to access private repositories"
+  description = "CodeStar connection ARN required for Bitbucket / GitHub integration with CodePipeline"
   default     = ""
 }
 
-variable "github_webhooks_token" {
+variable "codestar_output_artifact_format" {
   type        = string
-  description = "GitHub OAuth Token with permissions to create webhooks. If not provided, can be sourced from the `GITHUB_TOKEN` environment variable"
+  description = "Output artifact type for Source stage in pipeline. Valid values are \"CODE_ZIP\" (default) and \"CODEBUILD_CLONE_REF\". See https://docs.aws.amazon.com/codepipeline/latest/userguide/action-reference-CodestarConnectionSource.html"
+  default     = "CODE_ZIP"
+}
+
+variable "github_oauth_token" {
+  type        = string
+  description = "GitHub Oauth Token with permissions to access private repositories"
   default     = ""
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -3,8 +3,11 @@ terraform {
 
   required_providers {
     aws = {
-      source  = "hashicorp/aws"
-      version = ">= 3.34"
+      source = "hashicorp/aws"
+      # TODO: Remove upper bound after the transitive dependency `cloudposse/codebuild/aws` gets
+      #       proper support for AWS provider v5.
+      #       Related pull request: https://github.com/cloudposse/terraform-aws-codebuild/pull/123
+      version = ">= 3.34, < 5.0"
     }
   }
 }


### PR DESCRIPTION
## what

Allows connection to GitHub using CodeStar.

This PR contains a number of changes already in https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/225, and is still compatible with the token based configuration. Fundamentally, it merely allows the app to pass in the CodeStar connection ARN.

## why

Solves numerous difficulties using GitHub tokens.

## references

- https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/225
