### PR TITLE
fix: updated alb ingress module to the latest version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -22,7 +22,7 @@ resource "aws_cloudwatch_log_group" "app" {
 
 module "alb_ingress" {
   source  = "cloudposse/alb-ingress/aws"
-  version = "0.26.0"
+  version = "0.28.0"
 
   vpc_id = var.vpc_id
   port   = var.container_port


### PR DESCRIPTION
## what

Just update alb version module, I need it mostly because this target group name limit is killing 

## why
 
Sounds like a good idea to keep it up to date as well

## references

No issue for this, it super simple update, I tested it on my setup so it should be fine, but will see when all tests passes 