### PR TITLE
linux parameters add

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -96,6 +96,10 @@ module "container_definition" {
   mount_points                 = var.mount_points
   container_depends_on         = local.container_depends_on
   repository_credentials       = var.container_repo_credentials
+  linux_parameters = merge(
+    var.linux_parameters,
+    var.exec_enabled ? { initProcessEnabled = true } : {}
+  )
 
   log_configuration = var.cloudwatch_log_group_enabled ? {
     logDriver = var.log_driver

--- a/variables.tf
+++ b/variables.tf
@@ -52,6 +52,32 @@ variable "container_repo_credentials" {
   description = "Container repository credentials; required when using a private repo. This map currently supports a single key; \"credentialsParameter\", which should be the ARN of a Secrets Manager's secret holding the credentials"
 }
 
+# https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html
+variable "linux_parameters" {
+  type = object({
+    capabilities = optional(object({
+      add  = optional(list(string))
+      drop = optional(list(string))
+    }))
+    devices = optional(list(object({
+      containerPath = optional(string)
+      hostPath      = optional(string)
+      permissions   = optional(list(string))
+    })))
+    initProcessEnabled = optional(bool)
+    maxSwap            = optional(number)
+    sharedMemorySize   = optional(number)
+    swappiness         = optional(number)
+    tmpfs = optional(list(object({
+      containerPath = optional(string)
+      mountOptions  = optional(list(string))
+      size          = number
+    })))
+  })
+  description = "Linux-specific modifications that are applied to the container, such as Linux kernel capabilities. For more details, see https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_LinuxParameters.html"
+  default     = {}
+}
+
 variable "ecr_scan_images_on_push" {
   type        = bool
   description = "Indicates whether images are scanned after being pushed to the repository (true) or not (false)"


### PR DESCRIPTION
Re-do of https://github.com/cloudposse/terraform-aws-ecs-web-app/pull/189

## what

- set `initProcessEnabled = true` in container definition if user has opted to enable ecs_exec [(it is optional, but recommended by AWS)](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-exec.html#ecs-exec-enabling-and-using)

## why

- it will remove zombie processes in containers after exec is run
- because AWS recommended it