### PR TITLE
feat: Enable integration with multiple LBs

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Available targets:
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_lbs"></a> [additional\_lbs](#input\_additional\_lbs) | List of additional load balancer configurations. Each config should specify container\_name (optional), container\_port (optional, defaults to main container\_port), and target\_group\_arn | <pre>list(object({<br/>    container_name   = optional(string)<br/>    container_port   = optional(number)<br/>    target_group_arn = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_arn_suffix"></a> [alb\_arn\_suffix](#input\_alb\_arn\_suffix) | ARN suffix of the ALB for the Target Group | `string` | `""` | no |
 | <a name="input_alb_container_name"></a> [alb\_container\_name](#input\_alb\_container\_name) | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -37,6 +37,7 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_additional_lbs"></a> [additional\_lbs](#input\_additional\_lbs) | List of additional load balancer configurations. Each config should specify container\_name (optional), container\_port (optional, defaults to main container\_port), and target\_group\_arn | <pre>list(object({<br/>    container_name   = optional(string)<br/>    container_port   = optional(number)<br/>    target_group_arn = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_additional_tag_map"></a> [additional\_tag\_map](#input\_additional\_tag\_map) | Additional key-value pairs to add to each map in `tags_as_list_of_maps`. Not added to `tags` or `id`.<br/>This is for some rare cases where resources want additional configuration of tags<br/>and therefore take a list of maps with tag key, value, and additional configuration. | `map(string)` | `{}` | no |
 | <a name="input_alb_arn_suffix"></a> [alb\_arn\_suffix](#input\_alb\_arn\_suffix) | ARN suffix of the ALB for the Target Group | `string` | `""` | no |
 | <a name="input_alb_container_name"></a> [alb\_container\_name](#input\_alb\_container\_name) | The name of the container to associate with the ALB. If not provided, the generated container will be used | `string` | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,22 @@ locals {
     elb_name         = null
     target_group_arn = var.nlb_ingress_target_group_arn
   }
-  load_balancers = var.nlb_ingress_target_group_arn != "" ? [local.alb, local.nlb] : [local.alb]
+
+  additional_lbs = [
+    for config in var.additional_lbs : {
+      container_name   = config.container_name != null ? config.container_name : module.this.id
+      container_port   = config.container_port
+      elb_name         = null
+      target_group_arn = config.target_group_arn
+    }
+  ]
+
+  load_balancers = concat(
+    [local.alb],
+    var.nlb_ingress_target_group_arn != "" ? [local.nlb] : [],
+    local.additional_lbs
+  )
+
   init_container_definitions = [
     for init_container in var.init_containers : init_container["container_definition"]
   ]

--- a/main.tf
+++ b/main.tf
@@ -129,7 +129,7 @@ locals {
   additional_lbs = [
     for config in var.additional_lbs : {
       container_name   = config.container_name != null ? config.container_name : module.this.id
-      container_port   = config.container_port
+      container_port   = config.container_port != null ? config.container_port : var.container_port
       elb_name         = null
       target_group_arn = config.target_group_arn
     }

--- a/variables.tf
+++ b/variables.tf
@@ -1141,3 +1141,13 @@ variable "circuit_breaker_rollback_enabled" {
   description = "If `true`, Amazon ECS will roll back the service if a service deployment fails"
   default     = false
 }
+
+variable "additional_lbs" {
+  type = list(object({
+    container_name   = optional(string)
+    container_port   = number
+    target_group_arn = string
+  }))
+  description = "List of additional ALB configurations. Each config should specify container_name (optional), container_port, and target_group_arn"
+  default     = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1145,9 +1145,9 @@ variable "circuit_breaker_rollback_enabled" {
 variable "additional_lbs" {
   type = list(object({
     container_name   = optional(string)
-    container_port   = number
+    container_port   = optional(number)
     target_group_arn = string
   }))
-  description = "List of additional ALB configurations. Each config should specify container_name (optional), container_port, and target_group_arn"
+  description = "List of additional load balancer configurations. Each config should specify container_name (optional), container_port (optional, defaults to main container_port), and target_group_arn"
   default     = []
 }


### PR DESCRIPTION
## what

<!--
- Describe high-level what changed as a result of these commits (i.e. in plain-english, what do these changes mean?)
- Use bullet points to be concise and to the point.
-->

Enable ECS service registration in multiple LB target groups ([docs](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/register-multiple-targetgroups.html)). Currently, only 1 ALB and 1 NLB can be associated with a given service definition.

## why

<!--
- Provide the justifications for the changes (e.g. business case). 
- Describe why these changes were made (e.g. why do these commits fix the problem?)
- Use bullet points to be concise and to the point.
-->

There are scenarios where an ECS-hosted app needs to register itself into multiple target groups to handle use cases such as:
- traffic split between internal and internet-facing LBs
- handling of different protocols (e.g., HTTPS/gRPC) that require distinct target group configurations
- an app that exposes multiple ports (e.g. `80` + `8080` + `8443`)
- etc

## references

<!--
- Link to any supporting github issues or helpful documentation to add some context (e.g. stackoverflow). 
- Use `closes #123`, if this PR closes a GitHub issue `#123`
-->
