### PR TITLE
fix: make service_registries fields optional

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -241,9 +241,9 @@ variable "capacity_provider_strategies" {
 variable "service_registries" {
   type = list(object({
     registry_arn   = string
-    port           = number
-    container_name = string
-    container_port = number
+    port           = optional(number)
+    container_name = optional(string)
+    container_port = optional(number)
   }))
   description = "The service discovery registries for the service. The maximum number of service_registries blocks is 1. The currently supported service registry is Amazon Route 53 Auto Naming Service - `aws_service_discovery_service`; see `service_registries` docs https://www.terraform.io/docs/providers/aws/r/ecs_service.html#service_registries-1"
   default     = []


### PR DESCRIPTION
## what

Updated the `service_registries` variable to make `port`, `container_name`, and `container_port` optional.

## why

- The current implementation forces users to set all three fields, which leads to invalid configurations in ECS
- This change aligns the module with the actual ECS API behavior.
- It unblocks valid use cases, such as using service discovery in Elixir/Erlang clusters running on ECS Fargate

## references

🔗 [Terraform AWS Provider: service_registries input](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecs_service#service_registries)

 🔗 [AWS ECS Documentation – Service discovery](https://docs.aws.amazon.com/AmazonECS/latest/APIReference/API_ServiceRegistry.html)

- Closes https://github.com/cloudposse/terraform-aws-ecs-web-app/issues/299
