### PR TITLE
fix: Enable ECR lifecycle policy overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ module "default_backend_web_app" {
 | <a name="module_alb_ingress"></a> [alb\_ingress](#module\_alb\_ingress) | cloudposse/alb-ingress/aws | 0.28.0 |
 | <a name="module_alb_target_group_cloudwatch_sns_alarms"></a> [alb\_target\_group\_cloudwatch\_sns\_alarms](#module\_alb\_target\_group\_cloudwatch\_sns\_alarms) | cloudposse/alb-target-group-cloudwatch-sns-alarms/aws | 0.17.0 |
 | <a name="module_container_definition"></a> [container\_definition](#module\_container\_definition) | cloudposse/ecs-container-definition/aws | 0.58.1 |
-| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 0.41.0 |
+| <a name="module_ecr"></a> [ecr](#module\_ecr) | cloudposse/ecr/aws | 1.0.0 |
 | <a name="module_ecs_alb_service_task"></a> [ecs\_alb\_service\_task](#module\_ecs\_alb\_service\_task) | cloudposse/ecs-alb-service-task/aws | 0.78.0 |
 | <a name="module_ecs_cloudwatch_autoscaling"></a> [ecs\_cloudwatch\_autoscaling](#module\_ecs\_cloudwatch\_autoscaling) | cloudposse/ecs-cloudwatch-autoscaling/aws | 0.7.5 |
 | <a name="module_ecs_cloudwatch_sns_alarms"></a> [ecs\_cloudwatch\_sns\_alarms](#module\_ecs\_cloudwatch\_sns\_alarms) | cloudposse/ecs-cloudwatch-sns-alarms/aws | 0.12.2 |
@@ -247,6 +247,7 @@ module "default_backend_web_app" {
 | <a name="input_descriptor_formats"></a> [descriptor\_formats](#input\_descriptor\_formats) | Describe additional descriptors to be output in the `descriptors` output map.<br/>Map of maps. Keys are names of descriptors. Values are maps of the form<br/>`{<br/>   format = string<br/>   labels = list(string)<br/>}`<br/>(Type is `any` so the map values can later be enhanced to provide additional options.)<br/>`format` is a Terraform format string to be passed to the `format()` function.<br/>`labels` is a list of labels, in order, to pass to `format()` function.<br/>Label values will be normalized before being passed to `format()` so they will be<br/>identical to how they appear in `id`.<br/>Default is `{}` (`descriptors` output will be empty). | `any` | `{}` | no |
 | <a name="input_desired_count"></a> [desired\_count](#input\_desired\_count) | The desired number of tasks to start with. Set this to 0 if using DAEMON Service type. (FARGATE does not suppoert DAEMON Service type) | `number` | `1` | no |
 | <a name="input_docker_labels"></a> [docker\_labels](#input\_docker\_labels) | Map of Docker labels to assign to the container | `map(string)` | `null` | no |
+| <a name="input_ecr_enable_default_lifecycle_policy"></a> [ecr\_enable\_default\_lifecycle\_policy](#input\_ecr\_enable\_default\_lifecycle\_policy) | Enable default lifecycle policy for the ECR repository | `bool` | `true` | no |
 | <a name="input_ecr_enabled"></a> [ecr\_enabled](#input\_ecr\_enabled) | A boolean to enable/disable AWS ECR | `bool` | `true` | no |
 | <a name="input_ecr_image_tag_mutability"></a> [ecr\_image\_tag\_mutability](#input\_ecr\_image\_tag\_mutability) | The tag mutability setting for the ecr repository. Must be one of: `MUTABLE` or `IMMUTABLE` | `string` | `"IMMUTABLE"` | no |
 | <a name="input_ecr_scan_images_on_push"></a> [ecr\_scan\_images\_on\_push](#input\_ecr\_scan\_images\_on\_push) | Indicates whether images are scanned after being pushed to the repository (true) or not (false) | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -2,12 +2,13 @@ data "aws_region" "current" {}
 
 module "ecr" {
   source  = "cloudposse/ecr/aws"
-  version = "0.41.0"
+  version = "1.0.0"
   enabled = module.this.enabled && (var.ecr_enabled || var.codepipeline_enabled)
 
-  attributes           = ["ecr"]
-  scan_images_on_push  = var.ecr_scan_images_on_push
-  image_tag_mutability = var.ecr_image_tag_mutability
+  attributes              = ["ecr"]
+  scan_images_on_push     = var.ecr_scan_images_on_push
+  image_tag_mutability    = var.ecr_image_tag_mutability
+  enable_lifecycle_policy = var.ecr_enable_default_lifecycle_policy
 
   context = module.this.context
 }

--- a/variables.tf
+++ b/variables.tf
@@ -84,6 +84,12 @@ variable "ecr_scan_images_on_push" {
   default     = false
 }
 
+variable "ecr_enable_default_lifecycle_policy" {
+  type        = bool
+  description = "Enable default lifecycle policy for the ECR repository"
+  default     = true
+}
+
 variable "container_cpu" {
   type        = number
   description = "The vCPU setting to control cpu limits of container. (If FARGATE launch type is used below, this must be a supported vCPU size from the table here: https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-cpu-memory-error.html)"


### PR DESCRIPTION
## what

- Enable lifecycle policy overrides for the default ECR repository
- Upgrade `cloudposse/ecr/aws` from [v0.44.0](https://github.com/cloudposse/terraform-aws-ecr/releases/tag/v0.44.0) to [v1.0.0](https://github.com/cloudposse/terraform-aws-ecr/releases/tag/v1.0.0) (minor code changes, despite major version bump) 

## why

The module deploys an ECR repository by default using the `cloudposse/ecr/aws` module. It comes with a predefined ECR lifecycle policy that cannot be modified. This PR adds an ability to disable the default policy and replace it with your own (ECR identifiers are already exported and can be referenced in a [`aws_ecr_lifecycle_policy`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/ecr_lifecycle_policy) resource).

Note that only one `aws_ecr_lifecycle_policy` resource can be used with a given ECR repository.

Even though [`cloudposse/ecr/aws`](https://github.com/cloudposse/terraform-aws-ecr) allows for extensive lifecycle customizations, it doesn't make sense to expose all of its variables in the ECS web app module (that'd clutter the `variables.tf` file which is already quite long).

The pre-built ECR repository can obviously be entirely disabled (via `ecr_enabled` variable) and replaced by a separate `cloudposse/ecr/aws` module instance, but that's a really inconvenient solution for repositories that have already accumulated hundreds/thousands of images.

The default ECR lifecycle policy stays enabled for backward compatibility reasons.

## references

N/A